### PR TITLE
fix: repair flow task launch routing and agents URL sync

### DIFF
--- a/src/app/[locale]/flows/agents/page.tsx
+++ b/src/app/[locale]/flows/agents/page.tsx
@@ -340,22 +340,23 @@ export default function AgentsPage() {
       }).catch(() => {});
     }
 
-    // Check if already opened
+    let panelKey: number | null = null;
     setOpenedSessions(prev => {
       const existing = prev.find(
         o => o.sessionId === session.id && o.agentId === session.agentId,
       );
       if (existing) {
-        setActivePanel({ type: 'session', key: existing.key });
-        syncUrlParams({ agent: session.agentId, session: session.id });
+        panelKey = existing.key;
         return prev;
       }
-      // Open new instance
-      const key = nextKeyRef.current++;
-      setActivePanel({ type: 'session', key });
-      syncUrlParams({ agent: session.agentId, session: session.id });
-      return [...prev, { sessionId: session.id, agentId: session.agentId, key }];
+      panelKey = nextKeyRef.current++;
+      return [...prev, { sessionId: session.id, agentId: session.agentId, key: panelKey }];
     });
+
+    if (panelKey !== null) {
+      setActivePanel({ type: 'session', key: panelKey });
+      syncUrlParams({ agent: session.agentId, session: session.id });
+    }
   }, []);
 
   const handleNewSession = (agent: Agent) => {

--- a/src/components/agent-session-utils.ts
+++ b/src/components/agent-session-utils.ts
@@ -63,6 +63,8 @@ export interface SessionNavLink {
 // ── URL param sync helper ──
 
 export function syncUrlParams(params: Record<string, string | null | undefined>) {
+  if (typeof window === 'undefined') return;
+
   const url = new URL(window.location.href);
   for (const [key, value] of Object.entries(params)) {
     if (value) {
@@ -71,7 +73,16 @@ export function syncUrlParams(params: Record<string, string | null | undefined>)
       url.searchParams.delete(key);
     }
   }
-  window.history.replaceState({}, '', url.toString());
+
+  const next = url.toString();
+  if (next === window.location.href) return;
+
+  // Defer history update to avoid "setState during render" warnings from router internals.
+  setTimeout(() => {
+    if (window.location.href !== next) {
+      window.history.replaceState({}, '', next);
+    }
+  }, 0);
 }
 
 /**

--- a/src/components/ask-user-question-card.tsx
+++ b/src/components/ask-user-question-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, useMemo } from 'react';
 import { CheckCircle2, Loader2, MessageCircleQuestion, Send } from 'lucide-react';
 import type { ChatToolCall } from '@/types';
 
@@ -37,16 +37,23 @@ export const AskUserQuestionCard = memo(function AskUserQuestionCard({ toolCall 
   const [selections, setSelections] = useState<Record<number, string[]>>({});
   const [submitted, setSubmitted] = useState(false);
 
-  // Parse the input JSON
-  let questions: QuestionItem[] = [];
-  try {
-    const input = JSON.parse(toolCall.input);
-    questions = Array.isArray(input.questions) ? input.questions : [];
-  } catch {
-    return null;
-  }
-
-  if (questions.length === 0) return null;
+  const { questions, parseFailed } = useMemo(() => {
+    try {
+      const input = JSON.parse(toolCall.input);
+      const parsedQuestions = Array.isArray(input.questions)
+        ? input.questions as QuestionItem[]
+        : [];
+      return {
+        questions: parsedQuestions,
+        parseFailed: false,
+      };
+    } catch {
+      return {
+        questions: [] as QuestionItem[],
+        parseFailed: true,
+      };
+    }
+  }, [toolCall.input]);
 
   const isRunning = toolCall.status === 'running';
   const isCompleted = toolCall.status === 'completed';
@@ -123,6 +130,8 @@ export const AskUserQuestionCard = memo(function AskUserQuestionCard({ toolCall 
       dispatchAnswer(parts.join('\n'));
     }
   }, [allAnswered, submitted, isSingleQuestion, questions, selections, dispatchAnswer]);
+
+  if (parseFailed || questions.length === 0) return null;
 
   return (
     <div className="my-1.5 rounded-lg border border-indigo-200 bg-indigo-50/50 dark:border-indigo-800 dark:bg-indigo-950/30">

--- a/src/components/flow-chain.tsx
+++ b/src/components/flow-chain.tsx
@@ -427,9 +427,6 @@ function TreeItemRow({
   const [isOpen, setIsOpen] = useState(!!(item.children && item.children.length > 0));
   const [isAdding, setIsAdding] = useState(false);
 
-  if (!ctx) return null;
-  if (!showDeferred && item.deferred) return null;
-
   const hasChildren = !!(item.children && item.children.length > 0);
   const isDeferred = !!item.deferred;
   const filterDeferred = !showDeferred;
@@ -457,6 +454,9 @@ function TreeItemRow({
       setIsOpen(true);
     }
   }, [highlightTarget, hasChildren, item.children]);
+
+  if (!ctx) return null;
+  if (!showDeferred && item.deferred) return null;
 
   const { done: doneCount, total: totalCount } = hasChildren
     ? countDone(item.children!, filterDeferred)
@@ -648,20 +648,6 @@ export function SectionBlock({ section }: { section: Section }) {
 
   // AI launch handler
   const handleLaunchAI = async (item: TreeItem, ancestors: TreeItem[]) => {
-    // Check if session already exists
-    try {
-      const lookupRes = await fetch(`/api/tasks?flowTaskId=${item.id}`);
-      if (lookupRes.ok) {
-        const { session: existing } = await lookupRes.json();
-        if (existing) {
-          router.push(`/tasks/${existing.id}`);
-          return;
-        }
-      }
-    } catch {
-      // fall through
-    }
-
     const flowContext = collectFlowTaskContext({
       projectKey,
       projectName,
@@ -675,19 +661,33 @@ export function SectionBlock({ section }: { section: Section }) {
       globalContextIds: item.context?.globalContextIds,
     });
 
-    const res = await fetch('/api/tasks', {
+    const agentId = item.agentId?.trim() || 'agent-builtin-butler';
+    const promptLines: string[] = [];
+    promptLines.push(`任务：${flowContext.taskContent}`);
+    if (flowContext.taskDescription?.trim()) promptLines.push(`任务描述：${flowContext.taskDescription.trim()}`);
+    if (flowContext.sectionName?.trim()) promptLines.push(`所在板块：${flowContext.sectionName.trim()}`);
+    if (flowContext.ancestors.length > 0) promptLines.push(`上级路径：${flowContext.ancestors.map(a => a.content).join(' > ')}`);
+    if (flowContext.siblings.length > 0) promptLines.push(`同级任务：${flowContext.siblings.map(s => `${s.content}(${s.status})`).join('；')}`);
+    promptLines.push('请先给出执行计划，再开始实施。');
+
+    const res = await fetch('/api/agent-chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        title: item.content,
+        agentId,
+        message: promptLines.join('\n'),
         projectKey,
-        flowContext,
+        initialTitle: item.content,
       }),
     });
 
     if (res.ok) {
-      const session = await res.json();
-      router.push(`/tasks/${session.id}`);
+      const session = await res.json() as { sessionId: string };
+      const query = new URLSearchParams();
+      query.set('project', projectKey);
+      query.set('agent', agentId);
+      query.set('session', session.sessionId);
+      router.push(`/flows/agents?${query.toString()}`);
     }
   };
 

--- a/src/components/flow-editor.tsx
+++ b/src/components/flow-editor.tsx
@@ -308,32 +308,6 @@ export function FlowEditor({ projectKey, projectName, projectDescription, projec
       .finally(() => setLoading(false));
   }, [projectKey]);
 
-  // Fetch AI status (skip setState if unchanged)
-  const aiStatusRef = useRef<string>('');
-  useEffect(() => {
-    const fetchAIStatus = () => {
-      fetch('/api/tasks')
-        .then(res => res.ok ? res.json() : { tasks: [] })
-        .then(({ tasks }: { tasks: Array<{ flowContext?: { flowTaskId: string }; aiStatus?: 'running' | 'waiting' | 'confirm' | null }> }) => {
-          const map: AIStatusMap = {};
-          for (const t of tasks) {
-            if (t.flowContext?.flowTaskId && t.aiStatus) {
-              map[t.flowContext.flowTaskId] = t.aiStatus;
-            }
-          }
-          const serialized = JSON.stringify(map);
-          if (serialized !== aiStatusRef.current) {
-            aiStatusRef.current = serialized;
-            setAiStatusMap(map);
-          }
-        })
-        .catch(() => {});
-    };
-    fetchAIStatus();
-    const timer = setInterval(fetchAIStatus, 5000);
-    return () => clearInterval(timer);
-  }, []);
-
   const persist = useCallback((newData: FlowData) => {
     setData(newData);
     if (saveTimer.current) clearTimeout(saveTimer.current);

--- a/src/components/flow-shared.tsx
+++ b/src/components/flow-shared.tsx
@@ -171,6 +171,44 @@ export function collectFlowTaskContext(params: {
   };
 }
 
+const DEFAULT_FLOW_AGENT_ID = 'agent-builtin-butler';
+
+export function resolveFlowAgentId(item: TreeItem): string {
+  const id = item.agentId?.trim();
+  return id && id.length > 0 ? id : DEFAULT_FLOW_AGENT_ID;
+}
+
+export function buildFlowTaskPrompt(flowContext: FlowTaskContext): string {
+  const lines: string[] = [];
+  lines.push(`任务：${flowContext.taskContent}`);
+  if (flowContext.taskDescription?.trim()) {
+    lines.push(`任务描述：${flowContext.taskDescription.trim()}`);
+  }
+  if (flowContext.sectionName?.trim()) {
+    lines.push(`所在板块：${flowContext.sectionName.trim()}`);
+  }
+  if (flowContext.ancestors.length > 0) {
+    lines.push(`上级路径：${flowContext.ancestors.map(a => a.content).join(' > ')}`);
+  }
+  if (flowContext.siblings.length > 0) {
+    lines.push(`同级任务：${flowContext.siblings.map(s => `${s.content}(${s.status})`).join('；')}`);
+  }
+  lines.push('请先给出执行计划，再开始实施。');
+  return lines.join('\n');
+}
+
+export function buildFlowAgentUrl(params: {
+  projectKey?: string;
+  agentId: string;
+  sessionId: string;
+}): string {
+  const query = new URLSearchParams();
+  if (params.projectKey) query.set('project', params.projectKey);
+  query.set('agent', params.agentId);
+  query.set('session', params.sessionId);
+  return `/flows/agents?${query.toString()}`;
+}
+
 // --- Shared UI components ---
 
 export function StatusIcon({ status }: { status: Status }) {

--- a/src/components/miller-columns.tsx
+++ b/src/components/miller-columns.tsx
@@ -43,6 +43,9 @@ import {
   countDone,
   findItemById,
   collectFlowTaskContext,
+  resolveFlowAgentId,
+  buildFlowTaskPrompt,
+  buildFlowAgentUrl,
   StatusIcon,
   StatusBadge,
   AIStatusBadge,
@@ -119,9 +122,6 @@ const MillerColumnItem = memo(function MillerColumnItem({
   const { selectionPath, onSelect, setAddingToItemId } = useContext(MillerSelectionContext);
   const { showDeferred, highlightTarget, aiStatusMap, batchMode, selectedItems, toggleItemSelection, data, agents, agentMap } = useFlowData();
 
-  if (!ctx) return null;
-  if (!showDeferred && item.deferred) return null;
-
   const hasChildren = !!(item.children && item.children.length > 0);
   const isDeferred = !!item.deferred;
   const filterDeferred = !showDeferred;
@@ -140,7 +140,7 @@ const MillerColumnItem = memo(function MillerColumnItem({
   const handleLaunchAI = () => {
     const pathToItem = selectionPath.slice(0, depth);
     const ancestors = getAncestors(sectionItems, pathToItem);
-    ctx.onLaunchAI(item, ancestors);
+    ctx?.onLaunchAI(item, ancestors);
   };
 
   const rowRef = useRef<HTMLDivElement>(null);
@@ -205,6 +205,9 @@ const MillerColumnItem = memo(function MillerColumnItem({
   }, [isHighlighted]);
 
   const isItemSelected = selectedItems.has(item.id);
+
+  if (!ctx) return null;
+  if (!showDeferred && item.deferred) return null;
 
   return (
     <div
@@ -726,19 +729,6 @@ export function MillerSectionBlock({ section }: { section: Section }) {
 
   // AI launch handler
   const handleLaunchAI = useCallback(async (item: TreeItem, ancestors: TreeItem[]) => {
-    try {
-      const lookupRes = await fetch(`/api/tasks?flowTaskId=${item.id}`);
-      if (lookupRes.ok) {
-        const { session: existing } = await lookupRes.json();
-        if (existing) {
-          router.push(`/tasks/${existing.id}`);
-          return;
-        }
-      }
-    } catch {
-      // fall through
-    }
-
     const flowContext = collectFlowTaskContext({
       projectKey,
       projectName,
@@ -752,20 +742,22 @@ export function MillerSectionBlock({ section }: { section: Section }) {
       globalContextIds: item.context?.globalContextIds,
     });
 
-    const res = await fetch('/api/tasks', {
+    const agentId = resolveFlowAgentId(item);
+
+    const res = await fetch('/api/agent-chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        title: item.content,
+        agentId,
+        message: buildFlowTaskPrompt(flowContext),
         projectKey,
-        flowContext,
-        ...(item.agentId && { agentId: item.agentId }),
+        initialTitle: item.content,
       }),
     });
 
     if (res.ok) {
-      const session = await res.json();
-      router.push(`/tasks/${session.id}`);
+      const data = await res.json() as { sessionId: string };
+      router.push(buildFlowAgentUrl({ projectKey, agentId, sessionId: data.sessionId }));
     }
   }, [projectKey, projectName, section, data.sections, data.cycleDeadline, router]);
 


### PR DESCRIPTION
## Summary\n- replace deprecated /api/tasks + /tasks/{id} flow launch path with /api/agent-chat + /flows/agents\n- avoid Router setState during render by deferring URL sync and removing side effects from state updater\n- fix hook-order risk in flow item cards and ask-user-question card\n\n## Verification\n- 
pm run build passes on this branch\n- confirmed no remaining /api/tasks or /tasks/{id} app navigation references in src/components\n\n## Notes\n- this is a minimal regression fix and keeps existing lint baseline unchanged