### PR TITLE
Refine agents right sidebar workspace and preview UX

### DIFF
--- a/src/app/[locale]/flows/agents/page.tsx
+++ b/src/app/[locale]/flows/agents/page.tsx
@@ -13,6 +13,8 @@ import {
 import dynamic from 'next/dynamic';
 import type { Agent, ProviderId, OpenAIReasoningEffort } from '@/types';
 import { DEFAULT_AGENT_CAPABILITIES } from '@/types';
+import { FolderExplorerPanel } from '@/components/folder-explorer-panel';
+import { AgentSessionPromptStack } from '@/components/agent-session-prompt-stack';
 
 const AgentChatPanel = dynamic(
   () => import('@/components/agent-chat-panel').then(m => ({ default: m.AgentChatPanel })),
@@ -1396,6 +1398,7 @@ export default function AgentsPage() {
         )}
         </div>
 
+        {false && (
         <aside className="hidden w-[360px] shrink-0 border-l border-zinc-200 bg-[#fbfbfb] xl:flex xl:flex-col">
           <div className="flex items-start justify-between border-b border-zinc-200 px-5 py-4">
             <div className="min-w-0">
@@ -1543,6 +1546,58 @@ export default function AgentsPage() {
                   <div className="mt-1 font-medium text-zinc-800">{formatTokenCount(agentPromptTokens)}</div>
                 </div>
               </div>
+            </section>
+          </div>
+        </aside>
+        )}
+
+        <aside className="hidden w-[320px] shrink-0 border-l border-[#e7dfd0] bg-[#fcfaf5] shadow-[0_18px_48px_rgba(15,23,42,0.08)] xl:flex xl:flex-col dark:border-zinc-800 dark:bg-zinc-950">
+          <div className="flex h-full flex-col">
+            <section className="flex h-[52%] min-h-0 flex-col border-b border-[#e7dfd0] bg-[#f8f3e8] dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="flex h-11 items-center justify-between border-b border-[#e7dfd0] px-4 dark:border-zinc-800">
+                <div className="flex items-center gap-2">
+                  <FolderOpen className="h-4 w-4 text-[#5f5a4f] dark:text-zinc-300" />
+                  <h2 className="text-[13px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">项目工作区</h2>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!workspaceAgent) return;
+                    setCreating(false);
+                    setSelectedAgentId(workspaceAgent.id);
+                    setForm(agentToForm(workspaceAgent));
+                    setExpandedPrompt(false);
+                    setActivePanel({ type: 'agent', agentId: workspaceAgent.id, mode: 'settings' });
+                    syncUrlParams({ agent: workspaceAgent.id, session: workspaceSessionId });
+                  }}
+                  className="flex items-center gap-1.5 text-[#7f7461] transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  title="打开 Agent 设置"
+                >
+                  <Settings className="h-4 w-4" />
+                  <span className="text-[12px] font-medium">设置</span>
+                </button>
+              </div>
+
+              <div className="min-h-0 flex-1">
+                {activeProject?.path ? (
+                  <FolderExplorerPanel
+                    embedded
+                    onClose={() => {}}
+                    initialPath={activeProject.path}
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center px-6 text-center text-[12px] text-zinc-500 dark:text-zinc-400">
+                    选择项目后，这里会显示当前项目的文件结构。
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="flex h-[48%] min-h-0 flex-col bg-[#fcfbf8] dark:bg-zinc-950">
+              <AgentSessionPromptStack
+                key={promptStackItems.map((item) => `${item.scope}:${item.label}:${item.path}`).join('|')}
+                items={promptStackItems}
+              />
             </section>
           </div>
         </aside>

--- a/src/components/agent-session-prompt-stack.tsx
+++ b/src/components/agent-session-prompt-stack.tsx
@@ -1,0 +1,476 @@
+'use client';
+
+import { type ReactNode, useMemo, useState } from 'react';
+import {
+  ChevronDown,
+  Eye,
+  FileText,
+  FolderOpen,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react';
+
+export interface PromptStackSeedItem {
+  scope: 'Global' | 'Project' | 'Agent' | 'Session';
+  accent: string;
+  label: string;
+  path: string;
+  tokens: number | null;
+  description: string;
+}
+
+interface PromptCard {
+  id: string;
+  title: string;
+  path: string;
+  description: string;
+  tokens: number | null;
+}
+
+interface PromptGroup {
+  id: string;
+  label: string;
+  badge: string;
+  accent: string;
+  cards: PromptCard[];
+}
+
+interface EditorState {
+  groupId: string;
+  cardId: string | null;
+  title: string;
+  path: string;
+  description: string;
+  tokens: string;
+}
+
+interface PreviewState {
+  groupId: string;
+  card: PromptCard;
+}
+
+interface AgentSessionPromptStackProps {
+  items: PromptStackSeedItem[];
+}
+
+function makeInitialGroups(items: PromptStackSeedItem[]): PromptGroup[] {
+  return items.map((item) => ({
+    id: item.scope.toLowerCase(),
+    label:
+      item.scope === 'Global'
+        ? '全局'
+        : item.scope === 'Project'
+          ? '项目'
+          : item.scope === 'Agent'
+            ? 'Agent'
+            : '会话',
+    badge:
+      item.scope === 'Global'
+        ? 'GLOBAL'
+        : item.scope === 'Project'
+          ? 'PROJECT'
+          : item.scope === 'Agent'
+            ? 'AGENT'
+            : 'SESSION',
+    accent: item.accent,
+    cards: [
+      {
+        id: `${item.scope.toLowerCase()}-primary`,
+        title: item.label,
+        path: item.path,
+        description: item.description,
+        tokens: item.tokens,
+      },
+    ],
+  }));
+}
+
+function formatTokenLabel(tokens: number | null): string {
+  if (!tokens) return '';
+  if (tokens >= 1000) return `~${(tokens / 1000).toFixed(1)}k Token`;
+  return `~${tokens} Token`;
+}
+
+function getScopeTone(groupId: string) {
+  if (groupId === 'global') {
+    return {
+      rail: 'border-sky-200',
+      token: 'text-sky-600',
+      title: 'text-slate-900',
+      card: 'border-slate-200 hover:border-sky-200 hover:ring-sky-100',
+    };
+  }
+
+  if (groupId === 'project') {
+    return {
+      rail: 'border-amber-200',
+      token: 'text-amber-600',
+      title: 'text-slate-900',
+      card: 'border-slate-200 hover:border-amber-200 hover:ring-amber-100',
+    };
+  }
+
+  if (groupId === 'agent') {
+    return {
+      rail: 'border-emerald-200',
+      token: 'text-emerald-600',
+      title: 'text-emerald-900',
+      card: 'border-emerald-200 bg-emerald-50/50 hover:border-emerald-300 hover:ring-emerald-100',
+    };
+  }
+
+  return {
+    rail: 'border-violet-200',
+    token: 'text-violet-600',
+    title: 'text-slate-900',
+    card: 'border-slate-200 hover:border-violet-200 hover:ring-violet-100',
+  };
+}
+
+function PromptModal({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-slate-950/35 p-4 backdrop-blur-[2px]">
+      <div className="w-full max-w-md overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.18)]">
+        <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+          <div className="text-sm font-semibold text-slate-900">{title}</div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+            title="关闭"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="max-h-[min(70vh,720px)] overflow-y-auto px-4 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentSessionPromptStack({
+  items,
+}: AgentSessionPromptStackProps) {
+  const initialGroups = useMemo(() => makeInitialGroups(items), [items]);
+  const [groups, setGroups] = useState<PromptGroup[]>(initialGroups);
+  const [openGroupIds, setOpenGroupIds] = useState<string[]>(() =>
+    initialGroups.map((group) => group.id),
+  );
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  const groupMap = useMemo(
+    () => new Map(groups.map((group) => [group.id, group])),
+    [groups],
+  );
+
+  const toggleGroup = (groupId: string) => {
+    setOpenGroupIds((current) =>
+      current.includes(groupId)
+        ? current.filter((id) => id !== groupId)
+        : [...current, groupId],
+    );
+  };
+
+  const openCreate = (groupId: string) => {
+    setEditor({
+      groupId,
+      cardId: null,
+      title: '',
+      path: '',
+      description: '',
+      tokens: '',
+    });
+  };
+
+  const openEdit = (groupId: string, card: PromptCard) => {
+    setEditor({
+      groupId,
+      cardId: card.id,
+      title: card.title,
+      path: card.path,
+      description: card.description,
+      tokens: card.tokens ? String(card.tokens) : '',
+    });
+  };
+
+  const removeCard = (groupId: string, cardId: string) => {
+    setGroups((current) =>
+      current.map((group) =>
+        group.id === groupId
+          ? { ...group, cards: group.cards.filter((card) => card.id !== cardId) }
+          : group,
+      ),
+    );
+  };
+
+  const saveEditor = () => {
+    if (!editor) return;
+    const title = editor.title.trim();
+    if (!title) return;
+
+    setGroups((current) =>
+      current.map((group) => {
+        if (group.id !== editor.groupId) return group;
+
+        const nextCard: PromptCard = {
+          id: editor.cardId ?? `${group.id}-${Date.now()}`,
+          title,
+          path: editor.path.trim(),
+          description: editor.description.trim(),
+          tokens: editor.tokens.trim() ? Number(editor.tokens.trim()) || null : null,
+        };
+
+        if (editor.cardId) {
+          return {
+            ...group,
+            cards: group.cards.map((card) => (card.id === editor.cardId ? nextCard : card)),
+          };
+        }
+
+        return {
+          ...group,
+          cards: [...group.cards, nextCard],
+        };
+      }),
+    );
+
+    setEditor(null);
+  };
+
+  return (
+    <div className="relative flex h-full flex-col bg-[#fcfbf8]">
+      <div className="flex h-11 items-center justify-between border-b border-[#ece5d8] px-4">
+        <h3 className="text-[11px] font-bold uppercase tracking-[0.18em] text-[#9a8e7a]">
+          提示词注入栈
+        </h3>
+        <div className="text-[10px] text-[#b5aa97]">支持预览与编辑</div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="space-y-5">
+          {groups.map((group) => {
+            const isOpen = openGroupIds.includes(group.id);
+            const tone = getScopeTone(group.id);
+            return (
+              <section key={group.id} className="space-y-2.5">
+                <div className="flex items-center justify-between gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleGroup(group.id)}
+                    className="flex min-w-0 items-center gap-2 text-left"
+                  >
+                    <ChevronDown
+                      className={`h-4 w-4 text-slate-400 transition-transform ${
+                        isOpen ? '' : '-rotate-90'
+                      }`}
+                    />
+                    <FolderOpen className="h-4 w-4 text-[#cfb690]" />
+                    <span
+                      className={`inline-flex rounded-md px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] ${group.accent}`}
+                    >
+                      {group.label} ({group.badge})
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openCreate(group.id)}
+                    className="rounded-md p-1 text-slate-400 transition-colors hover:bg-white hover:text-slate-700"
+                    title={`新增${group.label}提示词`}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                </div>
+
+                {isOpen ? (
+                  <div className={`ml-2 border-l pl-4 ${tone.rail}`}>
+                    <div className="space-y-2">
+                      {group.cards.length > 0 ? (
+                        group.cards.map((card) => (
+                          <article
+                            key={card.id}
+                            className={`rounded-2xl border bg-white p-3 shadow-[0_6px_22px_rgba(15,23,42,0.04)] transition-all hover:ring-2 ${tone.card}`}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <button
+                                type="button"
+                                onClick={() => setPreview({ groupId: group.id, card })}
+                                className="min-w-0 flex-1 text-left"
+                              >
+                                <div className="mb-1 flex items-start gap-2">
+                                  <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400" />
+                                  <div className="min-w-0 flex-1">
+                                    <div className={`truncate font-mono text-[10px] font-bold ${tone.title}`}>
+                                      {card.title}
+                                    </div>
+                                    <div className="mt-1 truncate text-[10px] text-slate-400">
+                                      {card.path || '未设置路径'}
+                                    </div>
+                                  </div>
+                                </div>
+                                <p className="line-clamp-2 text-[10px] leading-5 text-slate-500">
+                                  {card.description || '暂无描述'}
+                                </p>
+                              </button>
+
+                              <div className="flex shrink-0 items-center gap-1">
+                                {card.tokens ? (
+                                  <span className={`mr-1 text-[9px] ${tone.token}`}>
+                                    {formatTokenLabel(card.tokens)}
+                                  </span>
+                                ) : null}
+                                <button
+                                  type="button"
+                                  onClick={() => setPreview({ groupId: group.id, card })}
+                                  className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                                  title="预览提示词"
+                                >
+                                  <Eye className="h-3.5 w-3.5" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => openEdit(group.id, card)}
+                                  className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                                  title="编辑提示词"
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => removeCard(group.id, card.id)}
+                                  className="rounded-md p-1 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
+                                  title="删除提示词"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </button>
+                              </div>
+                            </div>
+                          </article>
+                        ))
+                      ) : (
+                        <div className="rounded-2xl border border-dashed border-[#e4ddd0] bg-white/70 px-3 py-4 text-center text-[11px] text-slate-500">
+                          这个分组下还没有提示词卡片。
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </section>
+            );
+          })}
+        </div>
+      </div>
+
+      {preview ? (
+        <PromptModal
+          title={`${groupMap.get(preview.groupId)?.label ?? ''} 提示词预览`}
+          onClose={() => setPreview(null)}
+        >
+          <div className="space-y-4">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-3">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                文件名
+              </div>
+              <div className="mt-1 font-mono text-sm font-semibold text-slate-900">
+                {preview.card.title}
+              </div>
+              <div className="mt-2 break-all text-xs text-slate-500">
+                {preview.card.path || '未设置路径'}
+              </div>
+            </div>
+
+            <div>
+              <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                内容预览
+              </div>
+              <div className="min-h-[180px] rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm leading-6 text-slate-700 shadow-inner">
+                {preview.card.description || '当前还没有可预览的内容。后续接入真实提示词内容后，这里会显示完整文本。'}
+              </div>
+            </div>
+          </div>
+        </PromptModal>
+      ) : null}
+
+      {editor ? (
+        <PromptModal
+          title={editor.cardId ? '编辑提示词卡片' : `新增${groupMap.get(editor.groupId)?.label ?? ''}提示词卡片`}
+          onClose={() => setEditor(null)}
+        >
+          <div className="space-y-3">
+            <input
+              type="text"
+              value={editor.title}
+              onChange={(e) =>
+                setEditor((current) =>
+                  current ? { ...current, title: e.target.value } : current,
+                )
+              }
+              placeholder="卡片标题"
+              className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm outline-none transition-colors focus:border-slate-400"
+            />
+            <input
+              type="text"
+              value={editor.path}
+              onChange={(e) =>
+                setEditor((current) =>
+                  current ? { ...current, path: e.target.value } : current,
+                )
+              }
+              placeholder="文件路径"
+              className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm outline-none transition-colors focus:border-slate-400"
+            />
+            <input
+              type="text"
+              value={editor.tokens}
+              onChange={(e) =>
+                setEditor((current) =>
+                  current ? { ...current, tokens: e.target.value } : current,
+                )
+              }
+              placeholder="Token 估算，可留空"
+              className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm outline-none transition-colors focus:border-slate-400"
+            />
+            <textarea
+              value={editor.description}
+              onChange={(e) =>
+                setEditor((current) =>
+                  current ? { ...current, description: e.target.value } : current,
+                )
+              }
+              placeholder="提示词摘要或内容"
+              rows={7}
+              className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm outline-none transition-colors focus:border-slate-400"
+            />
+          </div>
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setEditor(null)}
+              className="rounded-lg px-3 py-2 text-sm text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={saveEditor}
+              className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-700"
+            >
+              保存
+            </button>
+          </div>
+        </PromptModal>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/folder-explorer-panel.tsx
+++ b/src/components/folder-explorer-panel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   FolderOpen, Folder, X, Loader2, Copy, ArrowUp,
   ChevronRight, ChevronDown, ExternalLink, Maximize2,
-  Plus, FilePlus, FolderPlus, Pencil, Trash2, AtSign,
+  FilePlus, FolderPlus, Pencil, Trash2, AtSign,
   GitBranch, FileText, ArrowLeft, RefreshCw,
 } from 'lucide-react';
 import { FileTypeIcon } from '@/components/file-type-icon';
@@ -40,6 +40,7 @@ interface FolderExplorerPanelProps {
   onInsertPath?: (path: string) => void;
   /** Auto-open this path on mount */
   initialPath?: string;
+  embedded?: boolean;
 }
 
 // ── Context Menu State ──
@@ -177,7 +178,12 @@ function pathDirname(p: string): string {
 // ─── MAIN COMPONENT ───
 // ══════════════════════════════════════════
 
-export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: FolderExplorerPanelProps) {
+export function FolderExplorerPanel({
+  onClose,
+  onInsertPath,
+  initialPath,
+  embedded = false,
+}: FolderExplorerPanelProps) {
   const [rootPath, setRootPath] = useState<string | null>(null);
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [loading, setLoading] = useState(false);
@@ -186,7 +192,12 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
 
   // File preview
-  const [viewingFile, setViewingFile] = useState<{ path: string; name: string; content: string } | null>(null);
+  const [viewingFile, setViewingFile] = useState<{
+    path: string;
+    name: string;
+    content: string | null;
+    previewError?: string | null;
+  } | null>(null);
   const [fileLoading, setFileLoading] = useState(false);
   const [expandedView, setExpandedView] = useState(false);
 
@@ -203,6 +214,10 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
   const [deleteConfirm, setDeleteConfirm] = useState<{ path: string; name: string; isDir: boolean } | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
+  const closePreview = useCallback(() => {
+    setViewingFile(null);
+    setExpandedView(false);
+  }, []);
 
   // Close context menu on click outside
   useEffect(() => {
@@ -228,10 +243,12 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
   // Close expanded file preview on Escape
   useEffect(() => {
     if (!expandedView) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setExpandedView(false); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closePreview();
+    };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [expandedView]);
+  }, [closePreview, expandedView]);
 
   // ── Load directory ──
   const loadRoot = useCallback(async (dirPath: string) => {
@@ -291,13 +308,27 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
     setError(null);
     try {
       const data = await apiReadFile(filePath);
-      setViewingFile({ path: data.path, name: fileName, content: data.content });
+      setViewingFile({
+        path: data.path,
+        name: fileName,
+        content: data.content,
+        previewError: null,
+      });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Read failed');
+      const message = err instanceof Error ? err.message : 'Read failed';
+      setViewingFile({
+        path: filePath,
+        name: fileName,
+        content: null,
+        previewError: message,
+      });
     } finally {
+      if (embedded) {
+        setExpandedView(true);
+      }
       setFileLoading(false);
     }
-  }, []);
+  }, [embedded]);
 
   // ── Go up ──
   const handleGoUp = useCallback(() => {
@@ -746,17 +777,92 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
     </div>
   );
 
+  const embeddedPreviewDialog = embedded && expandedView && viewingFile && (
+    <div className="fixed inset-0 z-[220] flex items-center justify-center bg-slate-950/38 p-5 backdrop-blur-[2px]" onClick={closePreview}>
+      <div
+        className="flex h-[min(88vh,900px)] w-[min(92vw,1240px)] flex-col overflow-hidden rounded-[28px] border border-[#e6ddcf] bg-[#fffdfa] shadow-[0_32px_120px_rgba(15,23,42,0.20)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-[#ece4d6] px-6 py-5">
+          <div className="min-w-0 flex items-center gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#f4e8d8] text-[#d97745]">
+              <FileTypeIcon filename={viewingFile.name} className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-3">
+                <div className="truncate text-lg font-semibold text-slate-900">{viewingFile.name}</div>
+              </div>
+              <div className="mt-1 truncate text-sm text-[#8c7d68]" title={viewingFile.path}>
+                {viewingFile.path}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={async () => {
+                try {
+                  await apiOpenFile(viewingFile.path);
+                } catch (err) {
+                  setError(err instanceof Error ? err.message : 'Open failed');
+                }
+              }}
+              className="inline-flex items-center gap-2 rounded-2xl bg-[#171312] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#2b2421]"
+            >
+              <Pencil className="h-4 w-4" />
+              编辑
+            </button>
+            <button
+              type="button"
+              onClick={closePreview}
+              className="rounded-2xl border border-[#d8ccbb] bg-[#f3ede3] px-4 py-2 text-sm font-semibold text-[#493f32] transition-colors hover:bg-[#ece3d6]"
+            >
+              关闭
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-[#fffdfa]">
+          {viewingFile.previewError ? (
+            <div className="flex h-full items-center justify-center p-8">
+              <div className="w-full max-w-xl rounded-3xl border border-[#eadfd0] bg-white px-6 py-8 text-center shadow-[0_16px_40px_rgba(15,23,42,0.06)]">
+                <div className="text-base font-semibold text-slate-900">
+                  Unsupported file type for preview
+                </div>
+                <div className="mt-2 text-sm text-[#8c7d68]">
+                  {viewingFile.previewError}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="min-w-max border-t border-[#f4ede2] bg-[#fffdfa] px-0 py-6">
+              <pre className="overflow-auto px-6 font-mono text-[13px] leading-8 text-slate-700">
+                {viewingFile.content}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
   // ══════════════════════════════════════════
   // ─── FILE PREVIEW ───
   // ══════════════════════════════════════════
 
-  if (viewingFile) {
+  if (viewingFile && !embedded) {
     return (
-      <div ref={panelRef} className="flex h-full flex-col border-l border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div
+        ref={panelRef}
+        className={`flex h-full flex-col bg-white dark:bg-zinc-950 ${
+          embedded ? '' : 'border-l border-zinc-200 dark:border-zinc-800'
+        }`}
+      >
         <div className="flex items-center gap-1.5 border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
           <button
             type="button"
-            onClick={() => { setViewingFile(null); setExpandedView(false); }}
+            onClick={closePreview}
             className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
             title="Back"
           >
@@ -795,24 +901,40 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
             </button>
           </div>
         </div>
-        <pre className="flex-1 overflow-auto p-2 font-mono text-[11px] leading-relaxed text-zinc-700 dark:text-zinc-300">
-          {viewingFile.content}
-        </pre>
+        {viewingFile.previewError ? (
+          <div className="flex flex-1 items-center justify-center p-6 text-center">
+            <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+              {viewingFile.previewError}
+            </div>
+          </div>
+        ) : (
+          <pre className="flex-1 overflow-auto p-2 font-mono text-[11px] leading-relaxed text-zinc-700 dark:text-zinc-300">
+            {viewingFile.content}
+          </pre>
+        )}
         {expandedView && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={() => setExpandedView(false)}>
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={closePreview}>
             <div className="flex max-h-[90vh] max-w-[90vw] flex-col rounded-lg border border-zinc-200 bg-white shadow-xl dark:border-zinc-700 dark:bg-zinc-900" onClick={(e) => e.stopPropagation()}>
               <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-2 dark:border-zinc-700">
                 <div className="flex items-center gap-2">
                   <FileTypeIcon filename={viewingFile.name} className="h-4 w-4" />
                   <span className="truncate font-mono text-sm text-zinc-700 dark:text-zinc-300">{viewingFile.name}</span>
                 </div>
-                <button type="button" onClick={() => setExpandedView(false)} className="rounded p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300">
+                <button type="button" onClick={closePreview} className="rounded p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300">
                   <X className="h-4 w-4" />
                 </button>
               </div>
-              <pre className="max-h-[80vh] flex-1 overflow-auto p-4 font-mono text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
-                {viewingFile.content}
-              </pre>
+              {viewingFile.previewError ? (
+                <div className="flex min-h-[240px] items-center justify-center p-6 text-center">
+                  <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                    {viewingFile.previewError}
+                  </div>
+                </div>
+              ) : (
+                <pre className="max-h-[80vh] flex-1 overflow-auto p-4 font-mono text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+                  {viewingFile.content}
+                </pre>
+              )}
             </div>
           </div>
         )}
@@ -827,49 +949,52 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
   return (
     <div
       ref={panelRef}
-      className="flex h-full flex-col border-l border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950"
+      className={`flex h-full flex-col bg-white dark:bg-zinc-950 ${
+        embedded ? '' : 'border-l border-zinc-200 dark:border-zinc-800'
+      }`}
       tabIndex={0}
       onKeyDown={handlePanelKeyDown}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
-        <div className="flex items-center gap-2">
-          <FolderOpen className="h-4 w-4 text-zinc-500" />
-          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Workspace</span>
+      {!embedded && (
+        <div className="flex items-center justify-between border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
+          <div className="flex items-center gap-2">
+            <FolderOpen className="h-4 w-4 text-zinc-500" />
+            <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Workspace</span>
+          </div>
+          <div className="flex items-center gap-1">
+            {rootPath && (
+              <>
+                <button type="button" onClick={handleRefresh} className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300" title="Refresh">
+                  <RefreshCw className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setInlineInput({ type: 'new-file', parentPath: rootPath });
+                  }}
+                  className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                  title="New File"
+                >
+                  <FilePlus className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setInlineInput({ type: 'new-folder', parentPath: rootPath });
+                  }}
+                  className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                  title="New Folder"
+                >
+                  <FolderPlus className="h-3.5 w-3.5" />
+                </button>
+              </>
+            )}
+            <button type="button" onClick={onClose} className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300" title="Close">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          {rootPath && (
-            <>
-              <button type="button" onClick={handleRefresh} className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300" title="Refresh">
-                <RefreshCw className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setInlineInput({ type: 'new-file', parentPath: rootPath });
-                }}
-                className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-                title="New File"
-              >
-                <FilePlus className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setInlineInput({ type: 'new-folder', parentPath: rootPath });
-                }}
-                className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-                title="New Folder"
-              >
-                <FolderPlus className="h-3.5 w-3.5" />
-              </button>
-            </>
-          )}
-          <button type="button" onClick={onClose} className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300" title="Close">
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
+      )}
 
       {/* Path input area (only when no root loaded) */}
       {!rootPath && (
@@ -904,33 +1029,49 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
         </div>
       )}
 
-      {/* Project info card */}
+      {/* Project info */}
       {rootPath && gitInfo && (
         <div className="border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
-          <div className="flex items-center gap-2">
-            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800">
-              <FolderOpen className="h-4 w-4 text-zinc-500" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5">
-                <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">
-                  {gitInfo.folderName}
+          {embedded ? (
+            <div className="flex items-center gap-2 text-[11px] text-zinc-500 dark:text-zinc-400">
+              <FolderOpen className="h-4 w-4 text-zinc-400 dark:text-zinc-500" />
+              <span className="truncate font-medium text-zinc-800 dark:text-zinc-200">
+                {gitInfo.folderName}
+              </span>
+              {gitInfo.hasGit && gitInfo.branch && (
+                <span className="flex shrink-0 items-center gap-1">
+                  <GitBranch className="h-3 w-3" />
+                  {gitInfo.branch}
                 </span>
-                <button type="button" onClick={handleGoUp} className="rounded p-0.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300" title="Go up">
-                  <ArrowUp className="h-3 w-3" />
-                </button>
+              )}
+              <span className="shrink-0">{gitInfo.dirCount} dirs, {gitInfo.fileCount} files</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800">
+                <FolderOpen className="h-4 w-4 text-zinc-500" />
               </div>
-              <div className="flex items-center gap-3 text-[11px] text-zinc-500 dark:text-zinc-400">
-                {gitInfo.hasGit && gitInfo.branch && (
-                  <span className="flex items-center gap-1">
-                    <GitBranch className="h-3 w-3" />
-                    {gitInfo.branch}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                    {gitInfo.folderName}
                   </span>
-                )}
-                <span>{gitInfo.dirCount} dirs, {gitInfo.fileCount} files</span>
+                  <button type="button" onClick={handleGoUp} className="rounded p-0.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300" title="Go up">
+                    <ArrowUp className="h-3 w-3" />
+                  </button>
+                </div>
+                <div className="flex items-center gap-3 text-[11px] text-zinc-500 dark:text-zinc-400">
+                  {gitInfo.hasGit && gitInfo.branch && (
+                    <span className="flex items-center gap-1">
+                      <GitBranch className="h-3 w-3" />
+                      {gitInfo.branch}
+                    </span>
+                  )}
+                  <span>{gitInfo.dirCount} dirs, {gitInfo.fileCount} files</span>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       )}
 
@@ -991,6 +1132,9 @@ export function FolderExplorerPanel({ onClose, onInsertPath, initialPath }: Fold
 
       {/* Delete confirmation dialog */}
       {deleteDialog}
+
+      {/* Embedded preview dialog */}
+      {embeddedPreviewDialog}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the agents page inspector with a dual-section right sidebar layout
- embed the workspace file tree in the top section with IDE-style presentation
- add prompt stack cards with modal preview/edit UI and file preview dialogs from the embedded tree

## Testing
- npm run lint -- src/components/folder-explorer-panel.tsx src/components/agent-session-prompt-stack.tsx src/app/[locale]/flows/agents/page.tsx