### PR TITLE
fix(chat,dev)：聚合模型选取与 dev/数据迁移修复

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "electron/dist/main.js",
   "scripts": {
     "postinstall": "node scripts/ensure-postcss-alloc-lru.mjs",
-    "dev": "concurrently --kill-others \"vite\" \"bun run --tsconfig tsconfig.json src/server/index.ts\"",
+    "dev": "concurrently --kill-others \"vite\" \"bun ./src/server/index.ts\"",
     "dev:client": "vite",
-    "dev:server": "bun run --tsconfig tsconfig.json src/server/index.ts",
+    "dev:server": "bun ./src/server/index.ts",
     "build": "vite build && bun build src/server/index.ts --outfile=dist/server/index.js --target=node --minify",
     "build:client": "vite build",
     "build:server": "bun build src/server/index.ts --outfile=dist/server/index.js --target=node --minify",

--- a/src/components/agent-chat/agent-chat-panel.tsx
+++ b/src/components/agent-chat/agent-chat-panel.tsx
@@ -1008,6 +1008,7 @@ export function AgentChatPanel({
     if (!text.trim() && (!images || images.length === 0)) return;
     if (isStreaming) return;
     if (hasProject && !projectKey) return;
+    if (chatModelOptions.length > 0 && (!chatProvider || !chatModel)) return;
 
     initTokenRef.current += 1;
 
@@ -1129,7 +1130,7 @@ export function AgentChatPanel({
       chatDispatch({ type: 'STREAM_END' });
       clearSessionRunning(targetSessionId);
     }
-  }, [agent.id, sessionId, isStreaming, hasProject, projectKey, chatProvider, chatModel, chatEffort, chatFastMode, connectToStream, onSessionChange, t, sessionConfig, setSessionIdSync, persistPendingUserQueue, sessionTitle, markSessionRunning, clearSessionRunning]);
+  }, [agent.id, sessionId, isStreaming, hasProject, projectKey, chatProvider, chatModel, chatModelOptions.length, chatEffort, chatFastMode, connectToStream, onSessionChange, t, sessionConfig, setSessionIdSync, persistPendingUserQueue, sessionTitle, markSessionRunning, clearSessionRunning]);
 
   useEffect(() => {
     doSendRef.current = doSend;

--- a/src/hooks/use-model-config.ts
+++ b/src/hooks/use-model-config.ts
@@ -18,9 +18,8 @@ import { useAvailableModels } from '@/hooks/use-available-models';
 
 type ModelSelectOption = { value: string; label: string };
 
-const INITIAL_PROVIDER: ProviderId = 'anthropic';
-const INITIAL_MODEL =
-  getProviderPreset(INITIAL_PROVIDER).models[0]?.id || '';
+/** 聊天栏未选模型时为空字符串；仅聚合列表中已配置凭据的供应商可选中 */
+type SelectedProvider = ProviderId | '';
 
 function providerLabel(id: ProviderId): string {
   return PROVIDER_LABELS[id] || id;
@@ -33,7 +32,7 @@ export interface CachedModelSettings {
 }
 
 export interface UseModelConfigReturn {
-  provider: ProviderId;
+  provider: SelectedProvider;
   model: string;
   /** 与 options[].value 对齐，供 ChatInput modelValue */
   compositeValue: string;
@@ -79,9 +78,7 @@ function pickPairFromItems(
   if (globalModel && inList(globalProvider, globalModel)) {
     return { providerId: globalProvider, modelId: globalModel };
   }
-  if (agent.defaultProvider && agent.defaultModel) {
-    return { providerId: agent.defaultProvider, modelId: agent.defaultModel };
-  }
+  // 不再选用「不在聚合列表中」的 Agent 默认（例如未配置 API Key 的 Anthropic）
   const first = items[0];
   return { providerId: first.providerId, modelId: first.value };
 }
@@ -91,23 +88,28 @@ export function useModelConfig(
   projectKey: string | null | undefined,
   cachedSettings?: CachedModelSettings,
 ): UseModelConfigReturn {
-  const { items: aggregateItems } = useAvailableModels();
+  const { items: aggregateItems, loading: aggregateLoading } = useAvailableModels();
 
-  const [provider, setProvider] = useState<ProviderId>(INITIAL_PROVIDER);
-  const [model, setModelState] = useState(INITIAL_MODEL);
+  const [provider, setProvider] = useState<SelectedProvider>('');
+  const [model, setModelState] = useState('');
   const [effort, setEffort] = useState<OpenAIReasoningEffort>(DEFAULT_OPENAI_REASONING_EFFORT);
   const [fastMode, setFastMode] = useState<boolean>(cachedSettings?.fastMode ?? false);
   const [globalEffort, setGlobalEffort] = useState<OpenAIReasoningEffort>(
     cachedSettings?.effort ?? DEFAULT_OPENAI_REASONING_EFFORT,
   );
   const [globalFastMode, setGlobalFastMode] = useState<boolean>(cachedSettings?.fastMode ?? false);
-  const [contextWindow, setContextWindow] = useState(getModelContextWindow(INITIAL_MODEL));
+  const [contextWindow, setContextWindow] = useState(() =>
+    getModelContextWindow(getProviderPreset('anthropic').models[0]?.id || ''),
+  );
   const [promptEstimate, setPromptEstimate] = useState(0);
 
   const globalDefaultsRef = useRef<{
     provider: ProviderId;
     model: string;
-  }>({ provider: INITIAL_PROVIDER, model: INITIAL_MODEL });
+  }>({
+    provider: 'anthropic',
+    model: getProviderPreset('anthropic').models[0]?.id || '',
+  });
   const [globalSettingsLoaded, setGlobalSettingsLoaded] = useState(false);
 
   const agentDefaultProvider = agent.defaultProvider;
@@ -192,9 +194,10 @@ export function useModelConfig(
     seededAgentIdRef.current = null;
   }, [agent.id]);
 
-  // 全局设置就绪后初始化 provider/model（每个 agent.id 一次；聚合列表可为空时用设置里的全局默认）
+  // 全局设置就绪且聚合列表拉取完成后初始化（避免先以空列表误判而落到 Anthropic 默认）
   useEffect(() => {
     if (!globalSettingsLoaded) return;
+    if (aggregateLoading) return;
     if (seededAgentIdRef.current === agent.id) return;
 
     const { provider: gp, model: gm } = globalDefaultsRef.current;
@@ -210,24 +213,15 @@ export function useModelConfig(
       ));
       setFastMode(providerId === 'openai' ? globalFastMode : false);
     } else {
-      if (agent.defaultProvider && agent.defaultModel) {
-        setProvider(agent.defaultProvider);
-        setModelState(agent.defaultModel);
-      } else {
-        setProvider(gp);
-        setModelState(gm || getProviderPreset(gp).models[0]?.id || INITIAL_MODEL);
-      }
-      const effP = (agent.defaultProvider ?? gp) as ProviderId;
-      setEffort(resolveOpenAIDefaultEffort(
-        agentDefaultOpenAIReasoningEffort,
-        effP,
-        globalEffort,
-      ));
-      setFastMode(effP === 'openai' ? globalFastMode : false);
+      setProvider('');
+      setModelState('');
+      setEffort(globalEffort);
+      setFastMode(false);
     }
     seededAgentIdRef.current = agent.id;
   }, [
     aggregateItems,
+    aggregateLoading,
     agent.id,
     agent.defaultProvider,
     agent.defaultModel,
@@ -237,11 +231,42 @@ export function useModelConfig(
     globalFastMode,
   ]);
 
+  // 首次进入时聚合尚为空、之后才拉到可用模型：补选列表内第一项（不展示未配置凭据的供应商）
+  useEffect(() => {
+    if (!globalSettingsLoaded || aggregateLoading) return;
+    if (aggregateItems.length === 0) return;
+    if (provider || model) return;
+    if (seededAgentIdRef.current !== agent.id) return;
+
+    const { provider: gp, model: gm } = globalDefaultsRef.current;
+    const { providerId, modelId } = pickPairFromItems(aggregateItems, agent, gp, gm);
+    setProvider(providerId);
+    setModelState(modelId);
+    setEffort(resolveOpenAIDefaultEffort(
+      agentDefaultOpenAIReasoningEffort,
+      providerId,
+      globalEffort,
+    ));
+    setFastMode(providerId === 'openai' ? globalFastMode : false);
+  }, [
+    aggregateItems,
+    aggregateLoading,
+    globalSettingsLoaded,
+    provider,
+    model,
+    agent.id,
+    agent.defaultProvider,
+    agent.defaultModel,
+    agentDefaultOpenAIReasoningEffort,
+    globalEffort,
+    globalFastMode,
+  ]);
+
   const options = useMemo((): ModelSelectOption[] => {
     const base = modelSelectOptionsFromAggregate(aggregateItems, providerLabel);
     if (provider && model) {
       const cur = compositeKeyForAggregateItem({
-        providerId: provider,
+        providerId: provider as ProviderId,
         value: model,
         label: model,
       });
@@ -249,7 +274,7 @@ export function useModelConfig(
         return [
           {
             value: cur,
-            label: `${model} · ${providerLabel(provider)}（当前）`,
+            label: `${model} · ${providerLabel(provider as ProviderId)}（当前）`,
           },
           ...base,
         ];
@@ -258,17 +283,22 @@ export function useModelConfig(
     return base;
   }, [aggregateItems, provider, model]);
 
-  const compositeValue = useMemo(
-    () =>
-      compositeKeyForAggregateItem({
-        providerId: provider,
-        value: model,
-        label: model,
-      }),
-    [provider, model],
-  );
+  const compositeValue = useMemo(() => {
+    if (!provider || !model) return '';
+    return compositeKeyForAggregateItem({
+      providerId: provider as ProviderId,
+      value: model,
+      label: model,
+    });
+  }, [provider, model]);
 
   const setModel = useCallback((compositeOrLegacy: string) => {
+    if (!compositeOrLegacy) {
+      setProvider('');
+      setModelState('');
+      setFastMode(false);
+      return;
+    }
     const parsed = parseAggregateCompositeKey(compositeOrLegacy);
     if (parsed) {
       setProvider(parsed.providerId);
@@ -322,7 +352,7 @@ export function useModelConfig(
   }, [agent.id, projectKey]);
 
   const applySessionConfig = useCallback((config: SessionConfig) => {
-    const nextProvider = (config.provider ?? agentDefaultProvider ?? provider) as ProviderId;
+    const nextProvider = (config.provider ?? agentDefaultProvider ?? (provider || undefined)) as ProviderId;
     if (config.provider) {
       setProvider(config.provider);
     }
@@ -352,27 +382,16 @@ export function useModelConfig(
     seededAgentIdRef.current = null;
     const { provider: gp, model: gm } = globalDefaultsRef.current;
 
-    let intendedProvider: ProviderId = gp;
+    let intendedProvider: SelectedProvider = '';
 
-    if (nextAgent.defaultProvider) {
-      intendedProvider = nextAgent.defaultProvider;
-      setProvider(nextAgent.defaultProvider);
-      if (nextAgent.defaultModel) {
-        setModelState(nextAgent.defaultModel);
-      } else {
-        const match = aggregateItems.find((it) => it.providerId === nextAgent.defaultProvider);
-        setModelState(
-          match?.value ?? getProviderPreset(nextAgent.defaultProvider).models[0]?.id ?? '',
-        );
-      }
-    } else if (aggregateItems.length > 0) {
+    if (aggregateItems.length > 0) {
       const picked = pickPairFromItems(aggregateItems, nextAgent, gp, gm);
       intendedProvider = picked.providerId;
       setProvider(picked.providerId);
       setModelState(picked.modelId);
     } else {
-      setProvider(gp);
-      setModelState(gm);
+      setProvider('');
+      setModelState('');
     }
 
     seededAgentIdRef.current = nextAgent.id;

--- a/src/lib/file-store.ts
+++ b/src/lib/file-store.ts
@@ -138,6 +138,88 @@ function getLegacyFlowIndexPath(): string {
   return path.join(getLegacyWorkflowsFlowsDir(), '_index.json');
 }
 
+/** 递归复制目录（供一次性迁移使用；目标侧已存在文件时不覆盖）。 */
+async function _migrateCopyDir(src: string, dest: string): Promise<void> {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const ent of entries) {
+    const from = path.join(src, ent.name);
+    const to = path.join(dest, ent.name);
+    if (ent.isDirectory()) {
+      await _migrateCopyDir(from, to);
+    } else {
+      try {
+        await fs.access(to);
+      } catch {
+        await fs.copyFile(from, to);
+      }
+    }
+  }
+}
+
+const AGENTS_DATA_TO_WORKSPACES_MARKER = path.join(DATA_DIR, '.pp-migrated-agents-data-to-workspaces');
+
+/**
+ * 将旧版 `agents/data/<id>/` 迁入规范路径 `agents/workspaces/<id>/`（幂等）。
+ */
+async function migrateLegacyAgentsDataToWorkspacesOnce(): Promise<void> {
+  try {
+    await fs.access(AGENTS_DATA_TO_WORKSPACES_MARKER);
+    return;
+  } catch {
+    /* proceed */
+  }
+
+  const legacyRoot = path.join(DATA_DIR, 'agents', 'data');
+  try {
+    await fs.access(legacyRoot);
+  } catch {
+    await fs.writeFile(AGENTS_DATA_TO_WORKSPACES_MARKER, new Date().toISOString(), 'utf-8').catch(() => {});
+    return;
+  }
+
+  const entries = await fs.readdir(legacyRoot, { withFileTypes: true });
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    let safe: string;
+    try {
+      safe = safeAgentIdSegment(ent.name);
+    } catch {
+      continue;
+    }
+    const src = path.join(legacyRoot, ent.name);
+    const dest = getAgentDataPath(safe);
+    try {
+      const existing = await fs.readdir(dest);
+      if (existing.length > 0) {
+        console.warn(`[migration] skip agents/data/${ent.name}: workspace already has files`);
+        continue;
+      }
+    } catch {
+      /* dest 不存在 */
+    }
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await _migrateCopyDir(src, dest);
+    await fs.rm(src, { recursive: true, force: true }).catch(() => {});
+    console.log(`[migration] agents/data/${ent.name} → agents/workspaces/${safe}`);
+  }
+
+  try {
+    const left = await fs.readdir(legacyRoot);
+    if (left.length === 0) {
+      await fs.rm(legacyRoot, { recursive: false });
+    } else if (left.length > 0) {
+      console.warn(
+        `[migration] ${legacyRoot} 仍有子项 (${left.join(', ')}); 请检查后手动整理`,
+      );
+    }
+  } catch {
+    /* 目录已删 */
+  }
+
+  await fs.writeFile(AGENTS_DATA_TO_WORKSPACES_MARKER, new Date().toISOString(), 'utf-8').catch(() => {});
+}
+
 /**
  * 首次启动时创建所有数据子目录。
  */


### PR DESCRIPTION
## 目标分支 / Base branch

- [x] 合并到 **`next`**（常规功能、重构、文档；对应 `feature/*`）
- [ ] 合并到 **`main`**（仅 `hotfix/*` 稳定线紧急修复）

## 说明 / Description

- 聊天模型下拉：仅从「聚合可用模型」列表选取；未配置凭据的供应商（如未填 Anthropic Key）不再作为默认选中，也不再插入仅用于占位的「（当前）」项。
- 等待 `/api/settings/aggregate-models` 拉取完成后再初始化选中项；列表由空变为有时自动补选列表内模型。
- 有模型选项但未选中时禁止发送消息。
- `dev` / `dev:server` 与 `electron-dev` 一致使用 `bun ./src/server/index.ts`。
- `file-store`：补全 `migrateLegacyAgentsDataToWorkspacesOnce` 与 `_migrateCopyDir`，避免后端启动时 `ReferenceError`。

## 改动类型 / Type of change

- [x] 缺陷修复
- [ ] 新功能（非破坏性）
- [ ] 破坏性变更
- [ ] 文档
- [ ] 重构
- [ ] 样式与格式
- [x] 配置（`package.json` 脚本）
- [ ] 测试

## 自检清单 / Checklist

- [x] 已自行审阅改动
- [x] 本地相关场景手动验证（dev 启动、聊天模型下拉）

## 测试说明 / Testing

1. `bun run dev`：Vite + Hono 可启动。
2. 仅配置 DeepSeek、未配置 Anthropic：聊天栏模型默认为 DeepSeek，不出现 Anthropic「（当前）」占位。

## 备注

分支已基于最新 `origin/next` cherry-pick 单提交，便于评审。
