### PR TITLE
feat(inbox): Agent Inbox — change awareness system

### DIFF
--- a/src/lib/agent-prompt-store.ts
+++ b/src/lib/agent-prompt-store.ts
@@ -60,6 +60,18 @@ export async function writePromptFile(agentId: string, content: string): Promise
   await snapshotPromptVersion(agentId);
   await fs.mkdir(getPromptsDir(), { recursive: true });
   await fs.writeFile(getPromptFilePath(agentId), content, 'utf-8');
+
+  // Emit change event for inbox routing
+  try {
+    const { changeEmitter } = await import('./change-emitter');
+    changeEmitter.emit({
+      type: 'prompt_updated',
+      sourceId: agentId,
+      summary: `Agent 提示词已更新`,
+      timestamp: new Date().toISOString(),
+      agentId,
+    });
+  } catch { /* non-critical */ }
 }
 
 /**

--- a/src/lib/change-emitter.ts
+++ b/src/lib/change-emitter.ts
@@ -1,0 +1,56 @@
+/**
+ * ChangeEmitter — process-level event bus for data mutations.
+ *
+ * Any module that writes persistent data (docs, todos, shared-memory, prompts, sessions)
+ * calls `changeEmitter.emit(...)` after the write succeeds.
+ *
+ * Subscribers (currently: InboxManager) decide which agents care about each event
+ * and route notifications to their inboxes.
+ */
+
+export type ChangeEventType =
+  | 'doc_updated'
+  | 'todo_changed'
+  | 'memory_written'
+  | 'prompt_updated'
+  | 'session_completed';
+
+export interface ChangeEvent {
+  type: ChangeEventType;
+  /** ID of the changed resource (docId, todoId, memory key, agentId, sessionId) */
+  sourceId: string;
+  /** Human-readable one-line summary */
+  summary: string;
+  /** ISO timestamp */
+  timestamp: string;
+  /** Optional: which project this change belongs to */
+  projectKey?: string;
+  /** Optional: which agent triggered this change */
+  agentId?: string;
+}
+
+type ChangeHandler = (event: ChangeEvent) => void;
+
+class ChangeEmitter {
+  private handlers: ChangeHandler[] = [];
+
+  subscribe(handler: ChangeHandler): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter(h => h !== handler);
+    };
+  }
+
+  emit(event: ChangeEvent): void {
+    for (const handler of this.handlers) {
+      try {
+        handler(event);
+      } catch (err) {
+        console.error('[ChangeEmitter] handler error:', err);
+      }
+    }
+  }
+}
+
+/** Singleton — import and use directly */
+export const changeEmitter = new ChangeEmitter();

--- a/src/lib/chat-managers/agent-chat-manager.ts
+++ b/src/lib/chat-managers/agent-chat-manager.ts
@@ -1052,6 +1052,19 @@ class AgentChatManager {
     };
     await persistSessionToDisk(session, this.buildExecutionSummary(run));
 
+    // Emit change event for inbox routing
+    try {
+      const { changeEmitter } = await import('../change-emitter');
+      changeEmitter.emit({
+        type: 'session_completed',
+        sourceId: run.sessionId,
+        summary: `Agent「${run.agentId}」会话已完成`,
+        timestamp: new Date().toISOString(),
+        projectKey: run.projectKey,
+        agentId: run.agentId,
+      });
+    } catch { /* non-critical */ }
+
     // ExecutionEvent 归约落盘（纯增量，不影响 messages JSONL，fire-and-forget）
     this.persistExecutionEvents(run).catch(err => {
       console.error(`${LOG_PREFIX} persistExecutionEvents error:`, err);
@@ -1219,6 +1232,7 @@ async function buildResourcePrompt(
   }
 
   merged.push({ type: 'global-prompt', id: '_global', priority: 1 });
+  merged.push({ type: 'inbox-digest', id: '_inbox', priority: 4 });
 
   if (projectKey) {
     merged.push({ type: 'project-prompt', id: '_project', priority: 2 });

--- a/src/lib/documents-store.ts
+++ b/src/lib/documents-store.ts
@@ -224,4 +224,18 @@ export async function saveDocsIndexToDocuments(data: DocsIndexData): Promise<voi
     documents: summaries,
     ...(data.categories?.length ? { categories: data.categories } : {}),
   });
+
+  // Emit change events for inbox routing
+  try {
+    const { changeEmitter } = await import('./change-emitter');
+    for (const d of fromApi) {
+      changeEmitter.emit({
+        type: 'doc_updated',
+        sourceId: d.id,
+        summary: `文档「${d.title}」已更新`,
+        timestamp: new Date().toISOString(),
+        projectKey: d.projectKey,
+      });
+    }
+  } catch { /* non-critical */ }
 }

--- a/src/lib/inbox-manager.ts
+++ b/src/lib/inbox-manager.ts
@@ -1,0 +1,201 @@
+/**
+ * InboxManager — per-agent change notification inbox.
+ *
+ * Each agent has a JSONL file at `agents/inboxes/{agentId}.jsonl`.
+ * When a ChangeEvent fires, InboxManager checks which agents watch
+ * the affected resource and appends an entry to their inboxes.
+ *
+ * On session start, the InboxDigestLoader reads unread entries
+ * and injects a "what changed since last time" section into the prompt.
+ */
+
+import { promises as fs } from 'fs';
+import { mkdirSync, appendFileSync } from 'fs';
+import path from 'path';
+
+import { changeEmitter, type ChangeEvent } from './change-emitter';
+import { listAgents } from './agents-store';
+import { parseJsonSafe, getDataDir } from './file-store';
+
+// ── Types ──
+
+export interface InboxEntry {
+  id: string;
+  type: ChangeEvent['type'];
+  sourceId: string;
+  summary: string;
+  createdAt: string;
+  read: boolean;
+  projectKey?: string;
+  fromAgentId?: string;
+}
+
+// ── Path helpers ──
+
+function getInboxDir(): string {
+  return path.join(getDataDir(), 'agents', 'inboxes');
+}
+
+function getInboxPath(agentId: string): string {
+  const safe = agentId.replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!safe) throw new Error(`Invalid agent id: ${agentId}`);
+  return path.join(getInboxDir(), `${safe}.jsonl`);
+}
+
+// ── Core operations ──
+
+/** Append an entry to an agent's inbox */
+export function push(agentId: string, entry: InboxEntry): void {
+  const filePath = getInboxPath(agentId);
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+  } catch { /* already exists */ }
+  appendFileSync(filePath, JSON.stringify(entry) + '\n', 'utf-8');
+}
+
+/** Read all entries (optionally only unread) */
+export async function list(agentId: string, unreadOnly = false): Promise<InboxEntry[]> {
+  const filePath = getInboxPath(agentId);
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const entries: InboxEntry[] = [];
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const entry = parseJsonSafe<InboxEntry>(trimmed);
+        if (unreadOnly && entry.read) continue;
+        entries.push(entry);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return entries;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/** Mark specific entries as read */
+export async function markRead(agentId: string, entryIds: string[]): Promise<void> {
+  const entries = await list(agentId);
+  const idSet = new Set(entryIds);
+  const updated = entries.map(e =>
+    idSet.has(e.id) ? { ...e, read: true } : e,
+  );
+  await writeAll(agentId, updated);
+}
+
+/** Mark all entries as read */
+export async function markAllRead(agentId: string): Promise<void> {
+  const entries = await list(agentId);
+  const updated = entries.map(e => ({ ...e, read: true }));
+  await writeAll(agentId, updated);
+}
+
+/** Get unread count */
+export async function getUnreadCount(agentId: string): Promise<number> {
+  const entries = await list(agentId, true);
+  return entries.length;
+}
+
+/** Atomically rewrite the full inbox file */
+async function writeAll(agentId: string, entries: InboxEntry[]): Promise<void> {
+  const filePath = getInboxPath(agentId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const content = entries.map(e => JSON.stringify(e)).join('\n') + (entries.length ? '\n' : '');
+  const tmpPath = filePath + `.tmp_${Date.now()}`;
+  await fs.writeFile(tmpPath, content, 'utf-8');
+  try {
+    await fs.rename(tmpPath, filePath);
+  } catch {
+    await fs.copyFile(tmpPath, filePath);
+    await fs.unlink(tmpPath).catch(() => {});
+  }
+}
+
+/** Prune old read entries (keep last N) */
+export async function prune(agentId: string, keepRead = 50): Promise<void> {
+  const entries = await list(agentId);
+  const unread = entries.filter(e => !e.read);
+  const read = entries.filter(e => e.read);
+  const kept = [...unread, ...read.slice(-keepRead)];
+  await writeAll(agentId, kept);
+}
+
+// ── Unique ID generator ──
+
+function makeEntryId(): string {
+  return `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ── ChangeEmitter subscriber ──
+
+/**
+ * Initialize: subscribe to change events and route to agent inboxes.
+ * Call once at server startup.
+ */
+export function initInboxRouting(): void {
+  changeEmitter.subscribe(async (event: ChangeEvent) => {
+    try {
+      const agents = await listAgents();
+      for (const agent of agents) {
+        if (shouldNotify(agent, event)) {
+          const entry: InboxEntry = {
+            id: makeEntryId(),
+            type: event.type,
+            sourceId: event.sourceId,
+            summary: event.summary,
+            createdAt: event.timestamp,
+            read: false,
+            projectKey: event.projectKey,
+            fromAgentId: event.agentId,
+          };
+          push(agent.id, entry);
+        }
+      }
+    } catch (err) {
+      console.error('[InboxManager] routing error:', err);
+    }
+  });
+}
+
+/**
+ * Determine if an agent should receive a notification for this event.
+ *
+ * Rules:
+ * 1. If agent has watchRefs, check if event matches any watched resource type
+ * 2. If agent has no watchRefs, it gets notifications for events in its project scope
+ * 3. Never notify an agent about its own changes (avoid loops)
+ */
+function shouldNotify(agent: { id: string; watchRefs?: Array<{ type: string }>; projectKey?: string }, event: ChangeEvent): boolean {
+  // Don't notify agent about its own actions
+  if (event.agentId === agent.id) return false;
+
+  // If agent has explicit watch refs, check type match
+  if (agent.watchRefs?.length) {
+    const watchedTypes = new Set(agent.watchRefs.map(r => changeTypeForResourceType(r.type)));
+    return watchedTypes.has(event.type);
+  }
+
+  // Default: notify if same project scope (or event is global)
+  if (agent.projectKey && event.projectKey) {
+    return agent.projectKey === event.projectKey;
+  }
+
+  // Global agents get all non-agent-specific events
+  return !event.agentId;
+}
+
+/** Map ResourceType → ChangeEventType for watch matching */
+function changeTypeForResourceType(resourceType: string): ChangeEvent['type'] | null {
+  switch (resourceType) {
+    case 'design-docs-index': return 'doc_updated';
+    case 'todo-list': return 'todo_changed';
+    case 'shared-memory': return 'memory_written';
+    case 'system-prompt':
+    case 'prompt-block': return 'prompt_updated';
+    default: return null;
+  }
+}

--- a/src/lib/resource-loaders/inbox-digest-loader.ts
+++ b/src/lib/resource-loaders/inbox-digest-loader.ts
@@ -1,0 +1,73 @@
+/**
+ * InboxDigestLoader — injects unread inbox entries into the agent prompt.
+ *
+ * When an agent session starts, this loader reads the agent's unread inbox
+ * and renders a "what changed since your last session" section.
+ * After injection, entries are marked as read.
+ *
+ * ref.id is always '_inbox'.
+ */
+
+import type { ResourceLoader, LoaderContext } from '../resource-loader';
+import type { ResourceRef, ResolvedResource } from '@/types/resource';
+import { list, markAllRead, type InboxEntry } from '@/lib/inbox-manager';
+
+const TYPE_LABELS: Record<string, string> = {
+  doc_updated: '📄 文档更新',
+  todo_changed: '✅ 待办变化',
+  memory_written: '🧠 共享记忆',
+  prompt_updated: '📝 提示词更新',
+  session_completed: '💬 会话完成',
+};
+
+export class InboxDigestLoader implements ResourceLoader {
+  readonly type = 'inbox-digest' as const;
+
+  async resolve(ref: ResourceRef, ctx: LoaderContext): Promise<ResolvedResource> {
+    if (!ctx.agentId) {
+      return { ref, content: '', ok: true };
+    }
+
+    const entries = await list(ctx.agentId, true);
+
+    if (entries.length === 0) {
+      return { ref, content: '', ok: true };
+    }
+
+    const lines = entries.map((e: InboxEntry) => {
+      const label = TYPE_LABELS[e.type] || e.type;
+      const time = formatTime(e.createdAt);
+      const from = e.fromAgentId ? ` (来自 ${e.fromAgentId})` : '';
+      return `- [${time}] ${label}: ${e.summary}${from}`;
+    });
+
+    const md = `自上次会话以来，你关注的资源发生了以下变化（共 ${entries.length} 条）：
+
+${lines.join('\n')}
+
+请根据这些变化判断是否需要采取行动。如果某些变化与你当前的工作相关，可以主动处理。`;
+
+    // Mark as read after injection
+    await markAllRead(ctx.agentId);
+
+    return {
+      ref,
+      content: md,
+      sectionTitle: '📬 收件箱 — 最近变化',
+      ok: true,
+    };
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    const hour = String(d.getHours()).padStart(2, '0');
+    const min = String(d.getMinutes()).padStart(2, '0');
+    return `${month}-${day} ${hour}:${min}`;
+  } catch {
+    return iso;
+  }
+}

--- a/src/lib/resource-loaders/index.ts
+++ b/src/lib/resource-loaders/index.ts
@@ -24,6 +24,7 @@ import { SkillResourceLoader } from './skill-loader';
 import { AgentDataInfoLoader } from './agent-data-info-loader';
 import { PromptBlockLoader } from './prompt-block-loader';
 import { LegacyContextLoader } from './legacy-context-loader';
+import { InboxDigestLoader } from './inbox-digest-loader';
 
 resourceRegistry.register(new DesignDocsIndexLoader());
 resourceRegistry.register(new ActiveTasksLoader());
@@ -40,3 +41,4 @@ resourceRegistry.register(new SkillResourceLoader());
 resourceRegistry.register(new AgentDataInfoLoader());
 resourceRegistry.register(new PromptBlockLoader());
 resourceRegistry.register(new LegacyContextLoader());
+resourceRegistry.register(new InboxDigestLoader());

--- a/src/lib/shared-memory.ts
+++ b/src/lib/shared-memory.ts
@@ -107,6 +107,19 @@ export async function writeMemory(opts: {
     return data;
   });
 
+  // Emit change event for inbox routing
+  try {
+    const { changeEmitter } = await import('./change-emitter');
+    changeEmitter.emit({
+      type: 'memory_written',
+      sourceId: opts.key,
+      summary: `共享记忆「${opts.key}」被${opts.author || '未知'}写入`,
+      timestamp: new Date().toISOString(),
+      projectKey: opts.projectKey,
+      agentId: undefined,
+    });
+  } catch { /* non-critical */ }
+
   return entry;
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,11 +30,13 @@ import agentChatRoutes from './routes/agent-chat';
 import schedulesRoutes from './routes/schedules';
 import eventTriggersRoutes from './routes/event-triggers';
 import communityRoutes from './routes/community';
+import agentInboxRoutes from './routes/agent-inbox';
 
 import { ensureDataDirV2Migrated } from '@/lib/file-store';
 import { ensureGlobalAgentsMigratedToPresets } from '@/lib/migrations/migrate-global-agents-to-presets';
 import { schedulerManager } from '@/lib/scheduler-manager';
 import { eventTriggerManager } from '@/lib/event-trigger-manager';
+import { initInboxRouting } from '@/lib/inbox-manager';
 
 const app = new Hono();
 
@@ -65,6 +67,7 @@ app.route('/api/agent-chat', agentChatRoutes);
 app.route('/api/schedules', schedulesRoutes);
 app.route('/api/event-triggers', eventTriggersRoutes);
 app.route('/api/community', communityRoutes);
+app.route('/api/agent-inbox', agentInboxRoutes);
 
 // --- Static file serving (production) ---
 const clientDistPath = path.resolve(__dirname, '../../dist/client');
@@ -92,6 +95,7 @@ const port = parseInt(
 async function startServer(): Promise<void> {
   await ensureDataDirV2Migrated();
   await ensureGlobalAgentsMigratedToPresets();
+  initInboxRouting();
   await schedulerManager.init();
   await eventTriggerManager.init();
   console.log(`[server] Starting Hono backend on http://127.0.0.1:${port}`);

--- a/src/server/routes/agent-inbox.ts
+++ b/src/server/routes/agent-inbox.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent Inbox API routes.
+ *
+ * GET  /api/agent-inbox/:agentId          — list inbox entries
+ * GET  /api/agent-inbox/:agentId/count    — unread count
+ * PATCH /api/agent-inbox/:agentId/read    — mark entries as read
+ * POST /api/agent-inbox/:agentId/read-all — mark all as read
+ */
+
+import { Hono } from 'hono';
+import * as inbox from '@/lib/inbox-manager';
+
+const app = new Hono();
+
+/** List inbox entries for an agent */
+app.get('/:agentId', async (c) => {
+  const agentId = c.req.param('agentId');
+  const unreadOnly = c.req.query('unread') === 'true';
+  const entries = await inbox.list(agentId, unreadOnly);
+  return c.json({ ok: true, entries });
+});
+
+/** Get unread count */
+app.get('/:agentId/count', async (c) => {
+  const agentId = c.req.param('agentId');
+  const count = await inbox.getUnreadCount(agentId);
+  return c.json({ ok: true, count });
+});
+
+/** Mark specific entries as read */
+app.patch('/:agentId/read', async (c) => {
+  const agentId = c.req.param('agentId');
+  const body = await c.req.json<{ ids: string[] }>();
+  await inbox.markRead(agentId, body.ids);
+  return c.json({ ok: true });
+});
+
+/** Mark all entries as read */
+app.post('/:agentId/read-all', async (c) => {
+  const agentId = c.req.param('agentId');
+  await inbox.markAllRead(agentId);
+  return c.json({ ok: true });
+});
+
+export default app;

--- a/src/server/routes/todos.ts
+++ b/src/server/routes/todos.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { modifyTodosMerged, readTodosMerged } from '@/lib/todo-file-store';
 import { HttpError } from '@/lib/http-error';
 import { dispatchTodoToAgent } from '@/lib/todo-dispatch';
+import { changeEmitter } from '@/lib/change-emitter';
 import type { TodosData, TodoItem, TodoLifecycle, TodoSubTask } from '@/types';
 
 const app = new Hono();
@@ -83,6 +84,15 @@ app.post('/', async (c) => {
     ...data,
     todos: [...data.todos, newTodo],
   }));
+
+  changeEmitter.emit({
+    type: 'todo_changed',
+    sourceId: newTodo.id,
+    summary: `新待办「${newTodo.title}」已创建`,
+    timestamp: now,
+    projectKey: newTodo.projectKey,
+    agentId: newTodo.agentId,
+  });
 
   return c.json(newTodo, 201);
 });
@@ -197,6 +207,16 @@ app.patch('/:id', async (c) => {
   }));
 
   if (!updated) throw new HttpError('Todo not found', 404);
+
+  const statusLabel = status ? `状态变为 ${status}` : '已更新';
+  changeEmitter.emit({
+    type: 'todo_changed',
+    sourceId: id,
+    summary: `待办「${(updated as TodoItem).title}」${statusLabel}`,
+    timestamp: new Date().toISOString(),
+    projectKey: (updated as TodoItem).projectKey,
+    agentId: (updated as TodoItem).agentId,
+  });
 
   return c.json(updated);
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -483,6 +483,18 @@ export interface Agent {
    * 片段存储在 data/prompts/blocks/{blockId}.md
    */
   promptRefs?: string[];
+  /**
+   * 关注清单：Agent 关注哪些资源的变化。
+   * 变化事件会自动投递到 Agent 收件箱（agents/inboxes/{agentId}.jsonl）。
+   * 若为空，默认按项目作用域接收同项目内的变化通知。
+   */
+  watchRefs?: ResourceRef[];
+  /**
+   * 关注策略：
+   * - 'notify'（默认）：变化写入收件箱，下次会话时 Agent 可以看到
+   * - 'auto-wake'：变化发生后自动创建后台会话让 Agent 处理
+   */
+  watchPolicy?: 'notify' | 'auto-wake';
   /** Persistent agent runtime status */
   agentStatus?: AgentStatus;
   archived?: boolean;

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -25,7 +25,8 @@ export type ResourceType =
   | 'project-prompt'               // Project-level prompt injected when projectKey is set
   | 'skill'                        // Skill bound to agent (name + description summary)
   | 'agent-data-info'              // Agent private data store directory listing
-  | 'prompt-block';                 // Reusable prompt fragment (from prompts/blocks/)
+  | 'prompt-block'                  // Reusable prompt fragment (from prompts/blocks/)
+  | 'inbox-digest';                 // Agent inbox — recent changes since last session
 
 // ── ResourceRef ──
 
@@ -48,6 +49,7 @@ export interface ResourceRef {
    * - global-prompt: '_global'
    * - project-prompt: '_project'
    * - prompt-block: blockId (maps to prompts/blocks/{blockId}.md)
+   * - inbox-digest: '_inbox'
    */
   id: string;
   /** Sort priority — lower values appear earlier in prompt. Default: 50 */


### PR DESCRIPTION
## Summary
- 新增 **Agent 收件箱系统**：ChangeEmitter → InboxManager → InboxDigestLoader 全链路
- 文档更新、TODO 变化、共享记忆写入、提示词修改、会话完成 5 类事件自动通知相关 Agent
- Agent 每次会话启动时，prompt 中自动注入「📬 收件箱 — 最近变化」摘要
- 新增 3 个 API 端点：列表、未读计数、标记已读
- Agent 类型扩展 `watchRefs` + `watchPolicy` 字段，支持关注特定资源

## 改动范围
- **新增 4 文件**：change-emitter.ts, inbox-manager.ts, inbox-digest-loader.ts, agent-inbox.ts (routes)
- **修改 9 文件**：在现有写入点加 emit 调用（每处 1-15 行），注册 loader 和路由

## Test plan
- [x] 创建 TODO → 检查 `/api/agent-inbox/:agentId` 返回通知条目
- [x] 未读计数 API `/api/agent-inbox/:agentId/count` 返回正确数字
- [ ] 启动 Agent 会话，验证 prompt 中出现收件箱摘要
- [ ] 标记已读后，下次会话不再注入已读条目
- [x] TypeScript 编译无新增错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)