### PR TITLE
feat(agents): tiered workspace rail and folder explorer i18n

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -21,6 +21,24 @@
     "schedules": "Schedules",
     "mcp": "MCP"
   },
+  "folderExplorer": {
+    "contextMenu": {
+      "referenceChat": "Insert path into chat",
+      "preview": "Preview",
+      "openInSystem": "Open in System",
+      "copyPath": "Copy Path",
+      "newFile": "New File",
+      "newFolder": "New Folder",
+      "rename": "Rename",
+      "delete": "Delete"
+    },
+    "deleteDialog": {
+      "confirm": "Delete {name}?",
+      "dirContentsHint": "(and all contents)",
+      "cancel": "Cancel",
+      "confirmDelete": "Delete"
+    }
+  },
   "mcpPage": {
     "title": "MCP",
     "subtitle": "Use Model Context Protocol inside ProjectPilot to connect third-party MCP servers and bring external tools and data into your workflow (same MCP ecosystem as Cursor, Claude Code, and similar hosts).",
@@ -633,10 +651,13 @@
       "expandSection": "Expand",
       "collapseSection": "Collapse",
       "tablistAria": "Workspace side panel",
+      "activityBarAria": "Workspace view switcher (VS Code–style activity bar)",
+      "detailTabsAria": "Data / Prompts / Capabilities switcher",
       "tabProject": "Project",
-      "tabAgentData": "Data",
+      "tabAgentData": "Agent data",
       "tabPromptStack": "Prompts",
-      "tabCapabilities": "Caps"
+      "tabCapabilities": "Caps",
+      "agentConfigGroup": "Agent config"
     },
     "picker": {
       "searchPlaceholder": "Search agents...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -21,6 +21,24 @@
     "schedules": "定时运行",
     "mcp": "MCP"
   },
+  "folderExplorer": {
+    "contextMenu": {
+      "referenceChat": "@引用到对话",
+      "preview": "预览",
+      "openInSystem": "在系统中打开",
+      "copyPath": "复制路径",
+      "newFile": "新建文件",
+      "newFolder": "新建文件夹",
+      "rename": "重命名",
+      "delete": "删除"
+    },
+    "deleteDialog": {
+      "confirm": "确定删除「{name}」？",
+      "dirContentsHint": "（将同时删除其下所有内容）",
+      "cancel": "取消",
+      "confirmDelete": "删除"
+    }
+  },
   "mcpPage": {
     "title": "MCP",
     "subtitle": "在 ProjectPilot 中通过 Model Context Protocol 接入第三方 MCP 服务，把外部工具与数据纳入你的工作流（与 Cursor、Claude Code 等使用的 MCP 生态一致）。",
@@ -634,10 +652,13 @@
       "expandSection": "展开",
       "collapseSection": "收起",
       "tablistAria": "工作区侧栏面板",
+      "activityBarAria": "工作区视图切换（VS Code 式活动栏）",
+      "detailTabsAria": "数据 / 提示词 / 能力 切换",
       "tabProject": "项目",
-      "tabAgentData": "数据",
-      "tabPromptStack": "提示栈",
-      "tabCapabilities": "能力"
+      "tabAgentData": "Agent 数据",
+      "tabPromptStack": "提示词",
+      "tabCapabilities": "能力",
+      "agentConfigGroup": "Agent 配置"
     },
     "picker": {
       "searchPlaceholder": "搜索 Agent...",

--- a/src/app/[locale]/flows/agents/page.tsx
+++ b/src/app/[locale]/flows/agents/page.tsx
@@ -2557,7 +2557,7 @@ export default function AgentsPage() {
         <aside
           id="agents-workspace-rail-aside"
           className={cn(
-            'flex h-full min-h-0 w-[min(100%,288px)] flex-col border-l border-border bg-muted/10 sm:w-[292px]',
+            'flex h-full min-h-0 w-[min(100%,288px)] flex-col border-l border-border bg-muted/10 sm:w-[292px] lg:w-[340px]',
             'lg:relative lg:shrink-0',
             'max-lg:absolute max-lg:right-0 max-lg:top-0 max-lg:z-50 max-lg:w-[min(100vw,320px)] max-lg:max-w-[90vw] max-lg:shadow-xl',
             'max-lg:transition-transform max-lg:duration-200 max-lg:ease-out',

--- a/src/components/agents-workspace-rail.tsx
+++ b/src/components/agents-workspace-rail.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslations } from '@/client/i18n/use-translations';
 import type { LucideIcon } from 'lucide-react';
-import { Folder, FolderOpen, Layers, ListTodo } from 'lucide-react';
+import { Bot, Folder, FolderOpen, Layers, ListTodo } from 'lucide-react';
 import { FolderExplorerPanel } from '@/components/folder-explorer-panel';
 import { AgentSessionPromptStack, type PromptStackSeedItem } from '@/components/agent-session-prompt-stack';
+import { useMediaQuery } from '@/hooks/use-media-query';
 import { cn } from '@/lib/utils';
 import type { AgentCapabilities } from '@/types';
 import { DEFAULT_AGENT_CAPABILITIES } from '@/types';
@@ -32,6 +33,9 @@ export interface AgentsWorkspaceRailProps {
 const NUM_TABS = 4;
 const ACTIVE_TAB_KEY = 'pp.agentsRail.activeTab';
 
+/** 一级活动栏外宽 72px（与左侧迷你栏一致）；水平内边距 `px-2` 为原 `px-4` 的一半 */
+const ACTIVITY_BAR_WIDTH_CLASS = 'w-[72px]';
+
 function readStoredActiveTab(): number {
   try {
     const raw = localStorage.getItem(ACTIVE_TAB_KEY);
@@ -55,11 +59,19 @@ export function AgentsWorkspaceRail({
 }: AgentsWorkspaceRailProps) {
   const t = useTranslations('agentsWorkspace');
   const tCap = useTranslations('agentsWorkspace.capabilities');
+  const lgUp = useMediaQuery('(min-width: 1024px)');
 
   const [activeTab, setActiveTab] = useState(readStoredActiveTab);
+  const lastDetailTabRef = useRef<number>(() => {
+    const s = readStoredActiveTab();
+    return s >= 1 && s <= 3 ? s : 1;
+  });
+
+  const isDetailTab = activeTab >= 1 && activeTab <= 3;
 
   const setTab = useCallback((idx: number) => {
     setActiveTab(idx);
+    if (idx >= 1 && idx <= 3) lastDetailTabRef.current = idx;
     try {
       localStorage.setItem(ACTIVE_TAB_KEY, String(idx));
     } catch { /* ignore */ }
@@ -204,47 +216,146 @@ export function AgentsWorkspaceRail({
     }
   };
 
+  const detailTabIndices = [1, 2, 3] as const;
+
+  const handleActivityClick = useCallback((group: 'project' | 'agent') => {
+    if (group === 'project') {
+      setTab(0);
+    } else {
+      setTab(isDetailTab ? activeTab : lastDetailTabRef.current);
+    }
+  }, [activeTab, isDetailTab, setTab]);
+
   return (
-    <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden [overflow-anchor:none]', className)}>
-      <div
-        role="tablist"
-        aria-label={t('workspaceRail.tablistAria')}
-        className="flex h-9 shrink-0 items-stretch gap-0.5 overflow-x-auto border-b border-border/80 bg-muted/35 px-1.5 pt-1 [-ms-overflow-style:none] [scrollbar-width:none] dark:bg-muted/25 [&::-webkit-scrollbar]:hidden"
-      >
-        {tabLabels.map((label, i) => {
-          const selected = activeTab === i;
-          return (
-            <button
-              key={i}
-              type="button"
-              role="tab"
-              id={`agents-rail-tab-${i}`}
-              aria-selected={selected}
-              aria-controls={`agents-rail-panel-${i}`}
-              title={fullTitles[i]}
-              onClick={() => setTab(i)}
-              className={cn(
-                'flex min-h-8 max-w-[min(11rem,42vw)] shrink-0 items-center gap-1.5 rounded-t-md border border-transparent px-2.5 py-1 text-left text-[11px] font-medium transition-colors',
-                selected
-                  ? 'border-border border-b-background bg-background text-foreground shadow-sm dark:border-border dark:bg-card'
-                  : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
-              )}
-            >
-              <span className="text-muted-foreground/80">{tabIcons[i]}</span>
-              <span className="min-w-0 flex-1 truncate">{label}</span>
-            </button>
-          );
-        })}
+    <div className={cn('flex min-h-0 flex-1 flex-row overflow-hidden [overflow-anchor:none]', className)}>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {/* 窄屏：顶栏四个入口（项目 / 数据 / 提示词 / 能力），扁平 */}
+        <div
+          role="tablist"
+          aria-label={t('workspaceRail.tablistAria')}
+          className="flex h-9 shrink-0 items-stretch gap-0.5 overflow-x-auto border-b border-border/80 bg-muted/35 px-1.5 pt-1 [-ms-overflow-style:none] [scrollbar-width:none] dark:bg-muted/25 lg:hidden [&::-webkit-scrollbar]:hidden"
+        >
+          {tabLabels.map((label, i) => {
+            const selected = activeTab === i;
+            return (
+              <button
+                key={i}
+                type="button"
+                role="tab"
+                id={`agents-rail-tab-${i}`}
+                aria-selected={selected}
+                aria-controls="agents-rail-main-panel"
+                title={fullTitles[i]}
+                onClick={() => setTab(i)}
+                className={cn(
+                  'flex min-h-8 max-w-[min(11rem,42vw)] shrink-0 items-center gap-1.5 rounded-t-md border border-transparent px-2.5 py-1 text-left text-[11px] font-medium transition-colors',
+                  selected
+                    ? 'border-border border-b-background bg-background text-foreground shadow-sm dark:border-border dark:bg-card'
+                    : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+                )}
+              >
+                <span className="text-muted-foreground/80">{tabIcons[i]}</span>
+                <span className="min-w-0 flex-1 truncate">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* 桌面：二级横排标签（Agent 数据 / 提示词 / 能力），仅一级选中「Agent 配置」时显示 */}
+        {isDetailTab && (
+          <div
+            role="tablist"
+            aria-label={t('workspaceRail.detailTabsAria')}
+            className="hidden h-8 shrink-0 items-stretch gap-0.5 border-b border-border/80 bg-muted/30 px-1.5 dark:bg-muted/20 lg:flex"
+          >
+            {detailTabIndices.map((idx) => {
+              const selected = activeTab === idx;
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  role="tab"
+                  id={`agents-rail-detail-${idx}`}
+                  aria-selected={selected}
+                  aria-controls="agents-rail-main-panel"
+                  title={fullTitles[idx]}
+                  onClick={() => setTab(idx)}
+                  className={cn(
+                    'flex min-h-7 min-w-0 flex-1 items-center justify-center gap-1 rounded-md border border-transparent px-2 text-[11px] font-medium transition-colors',
+                    selected
+                      ? 'border-border bg-background text-foreground shadow-sm dark:border-border dark:bg-card'
+                      : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+                  )}
+                >
+                  <span className="text-muted-foreground/80">{tabIcons[idx]}</span>
+                  <span className="min-w-0 truncate">{tabLabels[idx]}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <div
+          role="tabpanel"
+          id="agents-rail-main-panel"
+          aria-labelledby={
+            lgUp
+              ? (activeTab === 0 ? 'agents-rail-activity-project' : `agents-rail-detail-${activeTab}`)
+              : `agents-rail-tab-${activeTab}`
+          }
+          className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+        >
+          {renderActivePanel()}
+        </div>
       </div>
 
-      <div
-        role="tabpanel"
-        id={`agents-rail-panel-${activeTab}`}
-        aria-labelledby={`agents-rail-tab-${activeTab}`}
-        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      {/* 桌面：一级入口（项目工作区 / Agent 配置），尺寸对齐左侧 SidebarNavRow 迷你态 */}
+      <nav
+        aria-label={t('workspaceRail.activityBarAria')}
+        className={cn(
+          'hidden shrink-0 flex-col items-center gap-2 border-l border-border/80 bg-muted/25 px-2 py-3 dark:bg-muted/15 lg:flex',
+          ACTIVITY_BAR_WIDTH_CLASS,
+        )}
       >
-        {renderActivePanel()}
-      </div>
+        <button
+          type="button"
+          id="agents-rail-activity-project"
+          title={fullTitles[0]}
+          aria-label={fullTitles[0]}
+          aria-pressed={activeTab === 0}
+          aria-controls="agents-rail-main-panel"
+          onClick={() => handleActivityClick('project')}
+          className={cn(
+            'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors',
+            activeTab === 0
+              ? 'bg-background text-foreground shadow-sm ring-1 ring-border dark:bg-card'
+              : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+          )}
+        >
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center" aria-hidden>
+            <FolderOpen className="h-5 w-5 shrink-0" />
+          </span>
+        </button>
+        <button
+          type="button"
+          id="agents-rail-activity-agent"
+          title={t('workspaceRail.agentConfigGroup')}
+          aria-label={t('workspaceRail.agentConfigGroup')}
+          aria-pressed={isDetailTab}
+          aria-controls="agents-rail-main-panel"
+          onClick={() => handleActivityClick('agent')}
+          className={cn(
+            'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors',
+            isDetailTab
+              ? 'bg-background text-foreground shadow-sm ring-1 ring-border dark:bg-card'
+              : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground',
+          )}
+        >
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center" aria-hidden>
+            <Bot className="h-5 w-5 shrink-0" />
+          </span>
+        </button>
+      </nav>
     </div>
   );
 }

--- a/src/components/folder-explorer-panel.tsx
+++ b/src/components/folder-explorer-panel.tsx
@@ -244,6 +244,7 @@ export function FolderExplorerPanel({
 }: FolderExplorerPanelProps) {
   const tAgentsWs = useTranslations('agentsWorkspace');
   const tChat = useTranslations('chat');
+  const tFs = useTranslations('folderExplorer');
   const isDataRootLocked = Boolean(
     embedded && lockToInitialDataPath && initialPath && initialResolveMode === 'data',
   );
@@ -752,12 +753,12 @@ export function FolderExplorerPanel({
                   <AtSign className="h-3 w-3" />
                 </button>
               )}
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(node.path); }}
-                className="rounded p-0.5 text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
-                title="Copy path"
-              >
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(node.path); }}
+                  className="rounded p-0.5 text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+                  title={tFs('contextMenu.copyPath')}
+                >
                 <Copy className="h-3 w-3" />
               </button>
             </div>
@@ -820,42 +821,42 @@ export function FolderExplorerPanel({
     >
       {onInsertPath && (
         <ContextMenuItem
-          icon={AtSign} label="@引用到对话" shortcut=""
+          icon={AtSign} label={tFs('contextMenu.referenceChat')} shortcut=""
           onClick={() => handleContextMenuAction('reference', contextMenu.node)}
         />
       )}
       {!contextMenu.node.isDirectory && (
         <ContextMenuItem
-          icon={FileText} label="Preview" shortcut=""
+          icon={FileText} label={tFs('contextMenu.preview')} shortcut=""
           onClick={() => handleContextMenuAction('preview', contextMenu.node)}
         />
       )}
       <ContextMenuItem
-        icon={ExternalLink} label="Open in System" shortcut=""
+        icon={ExternalLink} label={tFs('contextMenu.openInSystem')} shortcut=""
         onClick={() => handleContextMenuAction('open-external', contextMenu.node)}
       />
       <ContextMenuItem
-        icon={Copy} label="Copy Path" shortcut=""
+        icon={Copy} label={tFs('contextMenu.copyPath')} shortcut=""
         onClick={() => handleContextMenuAction('copy-path', contextMenu.node)}
       />
       <div className="my-1 border-t border-zinc-100 dark:border-zinc-700" />
       <ContextMenuItem
-        icon={FilePlus} label="New File" shortcut=""
+        icon={FilePlus} label={tFs('contextMenu.newFile')} shortcut=""
         onClick={() => handleContextMenuAction('new-file', contextMenu.node)}
       />
       <ContextMenuItem
-        icon={FolderPlus} label="New Folder" shortcut=""
+        icon={FolderPlus} label={tFs('contextMenu.newFolder')} shortcut=""
         onClick={() => handleContextMenuAction('new-folder', contextMenu.node)}
       />
       {!isContextTargetRoot ? (
         <>
           <div className="my-1 border-t border-zinc-100 dark:border-zinc-700" />
           <ContextMenuItem
-            icon={Pencil} label="Rename" shortcut="F2"
+            icon={Pencil} label={tFs('contextMenu.rename')} shortcut="F2"
             onClick={() => handleContextMenuAction('rename', contextMenu.node)}
           />
           <ContextMenuItem
-            icon={Trash2} label="Delete" shortcut="Del" danger
+            icon={Trash2} label={tFs('contextMenu.delete')} shortcut="Del" danger
             onClick={() => handleContextMenuAction('delete', contextMenu.node)}
           />
         </>
@@ -871,8 +872,10 @@ export function FolderExplorerPanel({
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40" onClick={() => setDeleteConfirm(null)}>
       <div className="w-80 rounded-lg border border-zinc-200 bg-white p-4 shadow-xl dark:border-zinc-700 dark:bg-zinc-800" onClick={(e) => e.stopPropagation()}>
         <p className="mb-3 text-sm text-zinc-700 dark:text-zinc-300">
-          Delete <span className="font-medium">{deleteConfirm.name}</span>?
-          {deleteConfirm.isDir && ' (and all contents)'}
+          {tFs('deleteDialog.confirm', { name: deleteConfirm.name })}
+          {deleteConfirm.isDir && (
+            <span className="text-zinc-500 dark:text-zinc-400"> {tFs('deleteDialog.dirContentsHint')}</span>
+          )}
         </p>
         <div className="flex justify-end gap-2">
           <button
@@ -880,14 +883,14 @@ export function FolderExplorerPanel({
             onClick={() => setDeleteConfirm(null)}
             className="rounded px-3 py-1.5 text-xs text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
           >
-            Cancel
+            {tFs('deleteDialog.cancel')}
           </button>
           <button
             type="button"
             onClick={handleDeleteConfirm}
             className="rounded bg-red-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600"
           >
-            Delete
+            {tFs('deleteDialog.confirmDelete')}
           </button>
         </div>
       </div>

--- a/src/components/workspace-sidebar-rail.tsx
+++ b/src/components/workspace-sidebar-rail.tsx
@@ -22,7 +22,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useRouter, usePathname } from '@/client/i18n/routing';
 import { cn } from '@/lib/utils';
 
-/** YouTube 迷你导览宽度（仅图标） */
+/** 迷你导览宽度（仅图标）。与 `w-10` 按钮同宽时：`px-4` → 左右各 16px，与 40px 图标合计 72px，避免 `px-2` 左贴右空。 */
 const WIDTH_MINI_PX = 72;
 /** 展开宽度（图标 + 文案），约为原 240 的 2/3，避免占用过宽 */
 const WIDTH_EXPANDED_PX = 160;
@@ -53,8 +53,8 @@ function SidebarNavRow({
       title={mini ? undefined : label}
       aria-label={label}
       className={cn(
-        'flex h-10 w-full min-w-0 items-center rounded-lg text-left text-sm font-medium transition-colors',
-        mini ? 'gap-0' : 'gap-2',
+        'flex h-10 items-center rounded-lg text-left text-sm font-medium transition-colors',
+        mini ? 'w-10 shrink-0 gap-0' : 'w-full min-w-0 gap-2',
         active
           ? 'bg-zinc-900 text-white shadow-sm dark:bg-zinc-100 dark:text-zinc-900'
           : 'text-zinc-600 hover:bg-white hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200',
@@ -172,7 +172,7 @@ export function WorkspaceSidebarRail({
       <TooltipProvider delayDuration={mini ? 300 : 500} skipDelayDuration={0}>
         <div className="flex h-full min-w-0 flex-1 flex-col py-3">
           {scrollNav(
-            <div className="flex flex-col gap-2 px-2">
+            <div className={cn('flex flex-col gap-2', mini ? 'px-4' : 'px-2')}>
               <SidebarNavRow
                 mini={mini}
                 icon={FolderKanban}
@@ -273,8 +273,8 @@ export function WorkspaceSidebarRail({
 
           <div
             className={cn(
-              'shrink-0 px-2 pt-2',
-              mini ? 'mt-auto' : 'border-t border-zinc-200 dark:border-zinc-800',
+              'shrink-0 pt-2',
+              mini ? 'mt-auto px-4' : 'border-t border-zinc-200 px-2 dark:border-zinc-800',
             )}
           >
             <SidebarNavRow


### PR DESCRIPTION
Replaces the direct merge to \
ext\; please review and merge via PR.

## Summary
- Desktop Agents workspace rail: primary activity bar (project + agent config) with secondary tabs for agent data, prompts, and capabilities.
- Align right activity targets with left sidebar mini rail; reduce horizontal padding (\px-2\) in the 72px column.
- Add \olderExplorer\ i18n for context menu and delete dialog; wire \FolderExplorerPanel\ to \useTranslations\.
- Minor adjustments on agents page and workspace sidebar rail.

## How this PR was produced
Remote \
ext\ was reset to \9488258\ (pre direct-merge) so integration goes through this PR only.

Made with [Cursor](https://cursor.com)