### PR TITLE
fix(google-auth): embed credentials + open OAuth in browser

### DIFF
--- a/src/components/settings-google-sync-section.tsx
+++ b/src/components/settings-google-sync-section.tsx
@@ -57,32 +57,37 @@ export function SettingsGoogleSyncSection({
     const rp = encodeURIComponent(oauthReturnPath);
     const startHref = apiUrl(`/api/auth/google/start?returnPath=${rp}`);
 
-    // Electron：整页跳到 Google 常被识别为嵌入式浏览器 → 空白页；改为系统浏览器打开授权链接。
-    if (typeof window !== 'undefined' && window.electron?.openExternalUrl) {
-      setFlash(null);
-      try {
-        const res = await fetch(`${startHref}${startHref.includes('?') ? '&' : '?'}json=1`);
-        const j = (await res.json()) as { ok?: boolean; url?: string; error?: string };
-        if (!res.ok || !j.ok || !j.url) {
-          setFlash({
-            type: 'err',
-            text: j.error || (res.status === 503 ? t('googleSyncNotConfigured') : t('googleSyncError')),
-          });
-          return;
-        }
+    // Always open Google OAuth in system browser (even in web mode).
+    // Electron WebView is rejected by Google (disallowed_useragent),
+    // and in-page redirect from :4000 → :4500 → Google can lose cookies.
+    // Fetch the auth URL from backend, then open it externally.
+    setFlash(null);
+    try {
+      const res = await fetch(`${startHref}${startHref.includes('?') ? '&' : '?'}json=1`);
+      const j = (await res.json()) as { ok?: boolean; url?: string; error?: string };
+      if (!res.ok || !j.ok || !j.url) {
+        setFlash({
+          type: 'err',
+          text: j.error || t('googleSyncError'),
+        });
+        return;
+      }
+
+      if (typeof window !== 'undefined' && window.electron?.openExternalUrl) {
+        // Electron: use IPC to open in system browser
         const opened = await window.electron.openExternalUrl(j.url);
         if (opened?.error) {
           setFlash({ type: 'err', text: opened.error });
           return;
         }
-        setFlash({ type: 'ok', text: t('googleSyncOpenBrowserHint') });
-      } catch {
-        setFlash({ type: 'err', text: t('googleSyncError') });
+      } else {
+        // Web: open in new tab so current page state is preserved
+        window.open(j.url, '_blank', 'noopener');
       }
-      return;
+      setFlash({ type: 'ok', text: t('googleSyncOpenBrowserHint') });
+    } catch {
+      setFlash({ type: 'err', text: t('googleSyncError') });
     }
-
-    window.location.href = startHref;
   };
 
   const doPull = async () => {

--- a/src/server/routes/google-auth.ts
+++ b/src/server/routes/google-auth.ts
@@ -42,10 +42,16 @@ function cleanupPending(): void {
   }
 }
 
-function getGoogleClientConfig(): { clientId: string; clientSecret: string } | null {
-  const clientId = process.env.GOOGLE_CLIENT_ID?.trim();
-  const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim();
-  if (!clientId || !clientSecret) return null;
+// Built-in Google OAuth credentials for ProjectPilot.
+// End users don't need to configure these. Self-hosted deployments can
+// override via env vars if they want to use their own Google Cloud project.
+const BUILTIN_GOOGLE_CLIENT_ID =
+  '469599503504-dmhuho50val4lgtb7kslhg524e29vq5d.apps.googleusercontent.com';
+const BUILTIN_GOOGLE_CLIENT_SECRET = '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';
+
+function getGoogleClientConfig(): { clientId: string; clientSecret: string } {
+  const clientId = process.env.GOOGLE_CLIENT_ID?.trim() || BUILTIN_GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim() || BUILTIN_GOOGLE_CLIENT_SECRET;
   return { clientId, clientSecret };
 }
 
@@ -217,9 +223,6 @@ const googleAuth = new Hono();
 
 googleAuth.get('/start', (c) => {
   const cfg = getGoogleClientConfig();
-  if (!cfg) {
-    return c.json({ ok: false, error: 'Google OAuth is not configured (GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET).' }, 503);
-  }
   cleanupPending();
   const returnPath = sanitizeReturnPath(c.req.query('returnPath'), '/workspace/settings?section=googleSync');
   const codeVerifier = crypto.randomBytes(32).toString('base64url');
@@ -248,9 +251,6 @@ googleAuth.get('/start', (c) => {
 
 googleAuth.get('/callback', async (c) => {
   const cfg = getGoogleClientConfig();
-  if (!cfg) {
-    return c.text('Google OAuth not configured', 503);
-  }
   const code = c.req.query('code');
   const state = c.req.query('state');
   const err = c.req.query('error');
@@ -341,9 +341,6 @@ googleAuth.get('/status', (c) => {
 
 googleAuth.post('/sync-pull', async (c) => {
   const cfg = getGoogleClientConfig();
-  if (!cfg) {
-    return c.json({ ok: false, error: 'not_configured' }, 503);
-  }
   const raw = getCookie(c, SESSION_COOKIE);
   const sess = raw ? verifySession(raw) : null;
   if (!sess) {
@@ -367,9 +364,6 @@ googleAuth.post('/sync-pull', async (c) => {
 
 googleAuth.post('/sync-push', async (c) => {
   const cfg = getGoogleClientConfig();
-  if (!cfg) {
-    return c.json({ ok: false, error: 'not_configured' }, 503);
-  }
   const raw = getCookie(c, SESSION_COOKIE);
   const sess = raw ? verifySession(raw) : null;
   if (!sess) {


### PR DESCRIPTION
## Summary
- Embed Google OAuth Client ID/Secret as defaults — users no longer need to configure env vars
- Always open Google OAuth in system browser (Electron) or new tab (web) instead of in-page redirect

## Test plan
- [x] Google login works without setting GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET env vars
- [x] Web: clicking login opens Google auth in new tab
- [ ] Electron: clicking login opens system browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)