### PR TITLE
perf(server): lazy-load Hono API routes on first hit

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -50,7 +50,7 @@
 - 可通过 `PROJECT_PILOT_DATA_DIR` 环境变量自定义
 - JSON 文件读写有 50MB 大小限制
 - `writeJsonFile()` 自动创建父目录
-- **Hono 启动**：`src/server/index.ts` 在 `ensureDataDirV2Migrated` 之后会 **`schedulerManager.init()`** 与 **`eventTriggerManager.init()`**，进程重启后恢复 **cron 定时**与 **GitHub PR 轮询**（路线图 C1）
+- **Hono 启动**：`src/server/index.ts` 在 `ensureDataDirV2Migrated` 之后会 **`schedulerManager.init()`** 与 **`eventTriggerManager.init()`**，进程重启后恢复 **cron 定时**与 **GitHub PR 轮询**（路线图 C1）。**`/api/*` 业务路由**经 `lazy-route.ts` 在**首次命中**时 `import()` 对应模块（缩短 `tsx` 开发态冷启动；生产 `bun build --outfile` 单包仍会一次性加载）
 - **并行执行看板**：`agents/active-tasks.json`（多 Agent 运行时登记）；与 **Todo**（`todos/`）不同，见 `docs/领域与数据.md` §6
 - **会话（领域）= 连续上下文**：实现类型 **`AgentChatSession`** / 索引行 **`SessionMeta`**（`sessions/index.json` + `sessions/messages/*.jsonl`）；**`LegacyTaskWorkerSession`** 为历史形状，勿与当前会话混用。权威对照表见 **`docs/领域与数据.md` §0**
 - **Execution Event 落盘**：每个 Turn 结束后从内存归约出 `ExecutionEvent`（完整事件，非 delta），追加到 `sessions/events/<sessionId>.jsonl`。Run 元数据存 `sessions/runs/<sessionId>.json`。API：`GET /api/agent-chat/sessions/:id/events`、`/runs`、`POST /runs`、`PATCH /runs/:runId`。详见 `types/execution.ts`、`lib/execution-event-store.ts`、`docs/领域与数据.md` §3

--- a/docs/AI_AGENT_KNOWLEDGE_MAP.md
+++ b/docs/AI_AGENT_KNOWLEDGE_MAP.md
@@ -104,5 +104,6 @@
 | 2026-04-05 | **社区市场 P0**：LobeHub 类「发现 → 安装」调研与 OKR 文档；`GET /api/community/catalog` + 种子目录；`/workspace/community` + 侧栏入口；一键写入运行预设 | `docs/community-marketplace-lobechat-okr.md`、`src/data/community-catalog-seed.json`、`server/routes/community.ts`、`server/index.ts`、`components/community/*`、`flows/community/page.tsx`、`App.tsx`、`workspace-sidebar-rail.tsx`、`messages/zh.json` & `en.json`、本文件 |
 | 2026-04-06 | **Google 账号与云同步**：用户**按类选择**云端管理范围；**推荐最小云子集**仅为 **AI 供应商凭据**（与 `unified-credential-store` 对齐），会话/项目/文档等默认不上云 | `docs/design/google-account-cloud-sync-scope.md`、`docs/design/README.md`、`MEMORY.md`、本文件 |
 | 2026-04-06 | **PR #39 纳入设计参考**：Google OAuth + 本机 `accounts/<sub>/` 数据根、`file-store` AsyncLocalStorage、设置页登录与 `apiFetch` credentials；与「凭据可选上云」正交，见 `google-account-cloud-sync-scope.md` §「参考实现：PR #39」 | `docs/design/google-account-cloud-sync-scope.md`、本文件 |
+| 2026-04-07 | **Hono API 懒挂载**：`src/server/lazy-route.ts` + `index.ts` 对 `/api/*` 子树首包 `import()`（`tsx` 开发态冷启动更快） | `src/server/lazy-route.ts`、`src/server/index.ts`、`MEMORY.md`、本文件 |
 
 （后续变更请继续追加表格行，勿删历史。）

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,27 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { errorHandler } from './middleware/error-handler';
-
-import agentsRoutes from './routes/agents';
-import settingsRoutes from './routes/settings';
-import todosRoutes from './routes/todos';
-import dataRoutes from './routes/data';
-import docsRoutes from './routes/docs';
-import dimensionsRoutes from './routes/dimensions';
-import usageRoutes from './routes/usage';
-import promptsRoutes from './routes/prompts';
-import skillsRoutes from './routes/skills';
-import fsRoutes from './routes/fs';
-import recycleBinRoutes from './routes/recycle-bin';
-import uploadRoutes from './routes/upload';
-import projectsRoutes from './routes/projects';
-import aiDiscussRoutes from './routes/ai-discuss';
-import agentChatRoutes from './routes/agent-chat';
-import schedulesRoutes from './routes/schedules';
-import eventTriggersRoutes from './routes/event-triggers';
-import communityRoutes from './routes/community';
-import agentInboxRoutes from './routes/agent-inbox';
-import googleAuthRoutes from './routes/google-auth';
+import { lazyApiRoute } from './lazy-route';
 
 import { ensureDataDirV2Migrated } from '@/lib/file-store';
 import { ensureGlobalAgentsMigratedToPresets } from '@/lib/migrations/migrate-global-agents-to-presets';
@@ -86,27 +66,51 @@ app.use('/api/*', errorHandler);
 // --- Health check ---
 app.get('/health', (c) => c.json({ ok: true, uptime: process.uptime() }));
 
-// --- API Routes ---
-app.route('/api/agents', agentsRoutes);
-app.route('/api/settings', settingsRoutes);
-app.route('/api/todos', todosRoutes);
-app.route('/api/data', dataRoutes);
-app.route('/api/docs', docsRoutes);
-app.route('/api/dimensions', dimensionsRoutes);
-app.route('/api/usage', usageRoutes);
-app.route('/api', promptsRoutes);
-app.route('/api/skills', skillsRoutes);
-app.route('/api/fs', fsRoutes);
-app.route('/api/recycle-bin', recycleBinRoutes);
-app.route('/api/upload', uploadRoutes);
-app.route('/api/projects', projectsRoutes);
-app.route('/api/ai-discuss', aiDiscussRoutes);
-app.route('/api/agent-chat', agentChatRoutes);
-app.route('/api/schedules', schedulesRoutes);
-app.route('/api/event-triggers', eventTriggersRoutes);
-app.route('/api/community', communityRoutes);
-app.route('/api/agent-inbox', agentInboxRoutes);
-app.route('/api/auth/google', googleAuthRoutes);
+// --- API routes (lazy-loaded on first hit — see lazy-route.ts) ---
+const api = {
+  agents: '/api/agents',
+  settings: '/api/settings',
+  todos: '/api/todos',
+  data: '/api/data',
+  docs: '/api/docs',
+  dimensions: '/api/dimensions',
+  usage: '/api/usage',
+  root: '/api',
+  skills: '/api/skills',
+  fs: '/api/fs',
+  recycleBin: '/api/recycle-bin',
+  upload: '/api/upload',
+  projects: '/api/projects',
+  aiDiscuss: '/api/ai-discuss',
+  agentChat: '/api/agent-chat',
+  schedules: '/api/schedules',
+  eventTriggers: '/api/event-triggers',
+  community: '/api/community',
+  agentInbox: '/api/agent-inbox',
+  googleAuth: '/api/auth/google',
+} as const;
+
+app.route(api.agents, lazyApiRoute(api.agents, () => import('./routes/agents')));
+app.route(api.settings, lazyApiRoute(api.settings, () => import('./routes/settings')));
+app.route(api.todos, lazyApiRoute(api.todos, () => import('./routes/todos')));
+app.route(api.data, lazyApiRoute(api.data, () => import('./routes/data')));
+app.route(api.docs, lazyApiRoute(api.docs, () => import('./routes/docs')));
+app.route(api.dimensions, lazyApiRoute(api.dimensions, () => import('./routes/dimensions')));
+app.route(api.usage, lazyApiRoute(api.usage, () => import('./routes/usage')));
+app.route(api.skills, lazyApiRoute(api.skills, () => import('./routes/skills')));
+app.route(api.fs, lazyApiRoute(api.fs, () => import('./routes/fs')));
+app.route(api.recycleBin, lazyApiRoute(api.recycleBin, () => import('./routes/recycle-bin')));
+app.route(api.upload, lazyApiRoute(api.upload, () => import('./routes/upload')));
+app.route(api.projects, lazyApiRoute(api.projects, () => import('./routes/projects')));
+app.route(api.aiDiscuss, lazyApiRoute(api.aiDiscuss, () => import('./routes/ai-discuss')));
+app.route(api.agentChat, lazyApiRoute(api.agentChat, () => import('./routes/agent-chat')));
+app.route(api.schedules, lazyApiRoute(api.schedules, () => import('./routes/schedules')));
+app.route(api.eventTriggers, lazyApiRoute(api.eventTriggers, () => import('./routes/event-triggers')));
+app.route(api.community, lazyApiRoute(api.community, () => import('./routes/community')));
+app.route(api.agentInbox, lazyApiRoute(api.agentInbox, () => import('./routes/agent-inbox')));
+app.route(api.googleAuth, lazyApiRoute(api.googleAuth, () => import('./routes/google-auth')));
+/** 须挂在所有其它 `/api/...` 子树之后，否则会吞掉 `/api/auth/google` 等路径并 404 */
+app.route(api.root, lazyApiRoute(api.root, () => import('./routes/prompts')));
 
 // --- Static file serving (production) ---
 const clientDistPath = path.resolve(__dirname, '../../dist/client');

--- a/src/server/lazy-route.ts
+++ b/src/server/lazy-route.ts
@@ -1,0 +1,50 @@
+import { Hono } from 'hono';
+
+/**
+ * Mount an API subtree whose module loads on the first matching request (dev: faster cold start).
+ * Rewrites the URL pathname so the loaded {@link Hono} app sees paths relative to `mountPath`.
+ *
+ * Note: `bun build … --outfile=dist/server/index.js` bundles into one file, so production startup
+ * still parses the full bundle once; this mainly helps `tsx ./src/server/index.ts` and any future
+ * split-chunk server builds.
+ */
+export function lazyApiRoute(
+  mountPath: string,
+  loader: () => Promise<{ default: Hono }>,
+): Hono {
+  const wrapper = new Hono();
+  let cached: Hono | null = null;
+
+  const ensureLoaded = async (): Promise<Hono> => {
+    if (!cached) {
+      cached = (await loader()).default;
+    }
+    return cached;
+  };
+
+  wrapper.all('*', async (c) => {
+    const sub = await ensureLoaded();
+    const url = new URL(c.req.url);
+    const path = url.pathname;
+    const base = mountPath.endsWith('/') ? mountPath.slice(0, -1) : mountPath;
+
+    let relative: string;
+    if (path === base) {
+      relative = '/';
+    } else if (path.startsWith(`${base}/`)) {
+      relative = path.slice(base.length);
+      if (!relative.startsWith('/')) {
+        relative = `/${relative}`;
+      }
+    } else {
+      relative = path;
+    }
+
+    url.pathname = relative;
+    const forwarded = new Request(url, c.req.raw);
+    // @hono/node-server 无 ExecutionContext；访问 c.executionCtx 会抛错
+    return sub.fetch(forwarded, c.env);
+  });
+
+  return wrapper;
+}


### PR DESCRIPTION
## Summary

- Add `src/server/lazy-route.ts` and mount each `/api/*` subtree with a lazy `import()` on first matching request, so `tsx ./src/server/index.ts` does not eagerly load every route module at startup.
- Register mounts via a small `api` path map in `src/server/index.ts` (behavior unchanged for callers).

## Notes

- `bun build --outfile=dist/server/index.js` still produces one bundle, so production still parses the full server artifact once; the win is mainly **dev** cold start. Future `--splitting` could extend this further.
- Electron `cli-check` dynamic import was **not** included: `electron/main.ts` currently mixes other OAuth-related edits; that deferral can be a tiny follow-up PR.

## Docs

- `MEMORY.md` and `docs/AI_AGENT_KNOWLEDGE_MAP.md` updated per project convention.
