### PR TITLE
feat(documents): add documents-crud helper and projectpilot-documents MCP server

### DIFF
--- a/src/lib/agent-documents-mcp-server.ts
+++ b/src/lib/agent-documents-mcp-server.ts
@@ -1,0 +1,267 @@
+/**
+ * 统一文档域（设计文档 + 知识文档）进程内 MCP，替代 <save-doc> 流式标签。
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import {
+  listDocEntries,
+  createDocumentEntry,
+  getDocumentWithContent,
+  patchDocumentEntry,
+  deleteDocumentEntry,
+} from '@/lib/documents-crud';
+import { changeEmitter } from '@/lib/change-emitter';
+import { HttpError } from '@/lib/http-error';
+import type { DocStatus, DocumentKind } from '@/types';
+
+export const AGENT_DOCUMENTS_MCP_SERVER_KEY = 'projectpilot-documents';
+
+/** SDK 工具全名，供 UI / 流式事件识别 doc_create */
+export const AGENT_DOCUMENTS_DOC_CREATE_TOOL_NAME = `mcp__${AGENT_DOCUMENTS_MCP_SERVER_KEY}__doc_create`;
+
+const TOOL_NAMES = ['doc_list', 'doc_get', 'doc_create', 'doc_update', 'doc_delete'] as const;
+
+export function getAgentDocumentsMcpAllowedToolIds(): string[] {
+  return TOOL_NAMES.map((n) => `mcp__${AGENT_DOCUMENTS_MCP_SERVER_KEY}__${n}`);
+}
+
+export interface AgentDocumentsMcpContext {
+  agentId: string;
+  projectKey?: string;
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true as const };
+}
+
+function catchHttp(e: unknown): ReturnType<typeof errorResult> {
+  if (e instanceof HttpError) {
+    return errorResult(`${e.statusCode}: ${e.message}`);
+  }
+  return errorResult(e instanceof Error ? e.message : String(e));
+}
+
+/** 有会话项目时，参数 projectKey 若给出须与之一致；最终默认用会话项目。 */
+function effectiveProjectKey(ctx: AgentDocumentsMcpContext, param?: string): string {
+  const p = param?.trim();
+  const c = ctx.projectKey?.trim();
+  if (p) {
+    if (c && p !== c) {
+      throw new Error(`projectKey 与当前会话项目不一致（会话: ${c}，参数: ${p}）`);
+    }
+    return p;
+  }
+  if (!c) {
+    throw new Error('当前会话无项目上下文：创建/列表时请显式传入 projectKey');
+  }
+  return c;
+}
+
+function optionalProjectKey(ctx: AgentDocumentsMcpContext, param?: string): string | undefined {
+  const p = param?.trim();
+  const c = ctx.projectKey?.trim();
+  if (p) {
+    if (c && p !== c) {
+      throw new Error(`projectKey 与当前会话项目不一致（会话: ${c}，参数: ${p}）`);
+    }
+    return p;
+  }
+  return c || undefined;
+}
+
+async function assertDocInScope(ctx: AgentDocumentsMcpContext, docProjectKey: string): Promise<void> {
+  const c = ctx.projectKey?.trim();
+  if (c && docProjectKey !== c) {
+    throw new Error('无权访问其他项目的文档');
+  }
+}
+
+export function createAgentDocumentsMcpServer(ctx: AgentDocumentsMcpContext) {
+  return createSdkMcpServer({
+    name: AGENT_DOCUMENTS_MCP_SERVER_KEY,
+    version: '0.1.0',
+    tools: [
+      tool(
+        'doc_list',
+        '列出文档条目（默认当前项目；可传 projectKey 或 documentKind 过滤）。',
+        {
+          projectKey: z.string().optional(),
+          documentKind: z.enum(['design_doc', 'knowledge']).optional(),
+          status: z.enum(['active', 'draft', 'deprecated']).optional(),
+        },
+        async ({ projectKey, documentKind, status }) => {
+          try {
+            const pk = optionalProjectKey(ctx, projectKey);
+            if (!pk) {
+              const data = await listDocEntries({ documentKind: documentKind ?? null, status: status ?? null });
+              if (data.mode === 'all_projects') {
+                const slim: Record<string, unknown[]> = {};
+                for (const [k, entries] of Object.entries(data.projects ?? {})) {
+                  slim[k] = entries.map(slimEntry);
+                }
+                return jsonResult({ projects: slim });
+              }
+              return jsonResult({ docs: (data.docs ?? []).map(slimEntry) });
+            }
+            const data = await listDocEntries({
+              projectKey: pk,
+              documentKind: documentKind ?? null,
+              status: status ?? null,
+            });
+            return jsonResult({ projectKey: pk, docs: (data.docs ?? []).map(slimEntry) });
+          } catch (e) {
+            return catchHttp(e);
+          }
+        },
+      ),
+
+      tool(
+        'doc_get',
+        '读取文档元数据与正文（Markdown）。',
+        { id: z.string().min(1) },
+        async ({ id }) => {
+          try {
+            const { entry, content } = await getDocumentWithContent(id);
+            await assertDocInScope(ctx, entry.projectKey);
+            return jsonResult({ entry: slimEntry(entry), content });
+          } catch (e) {
+            return catchHttp(e);
+          }
+        },
+      ),
+
+      tool(
+        'doc_create',
+        '新建文档（设计文档或知识文档）。projectKey 默认当前会话项目。',
+        {
+          projectKey: z.string().optional(),
+          title: z.string().min(1).max(500),
+          description: z.string().max(5000).optional(),
+          content: z.string().max(2_000_000).optional(),
+          documentKind: z.enum(['design_doc', 'knowledge']).optional(),
+          category: z.string().optional(),
+          tags: z.array(z.string()).optional(),
+          status: z.enum(['active', 'draft', 'deprecated']).optional(),
+          supersedes: z.string().optional(),
+        },
+        async (args) => {
+          try {
+            const pk = effectiveProjectKey(ctx, args.projectKey);
+            const entry = await createDocumentEntry({
+              projectKey: pk,
+              title: args.title,
+              description: args.description,
+              content: args.content,
+              documentKind: (args.documentKind ?? 'design_doc') as DocumentKind,
+              category: args.category,
+              tags: args.tags,
+              status: args.status as DocStatus | undefined,
+              supersedes: args.supersedes,
+            });
+            changeEmitter.emit({
+              type: 'doc_updated',
+              sourceId: entry.id,
+              summary: `文档「${entry.title}」已创建`,
+              timestamp: new Date().toISOString(),
+              projectKey: entry.projectKey,
+              agentId: ctx.agentId,
+            });
+            return jsonResult({
+              ok: true,
+              entry: slimEntry(entry),
+            });
+          } catch (e) {
+            return catchHttp(e);
+          }
+        },
+      ),
+
+      tool(
+        'doc_update',
+        '更新文档元数据与/或正文。',
+        {
+          id: z.string().min(1),
+          title: z.string().max(500).optional(),
+          description: z.string().max(5000).optional(),
+          content: z.string().max(2_000_000).optional(),
+          category: z.string().optional(),
+          tags: z.array(z.string()).nullable().optional(),
+          status: z.enum(['active', 'draft', 'deprecated']).optional(),
+          supersedes: z.string().optional(),
+          supersededBy: z.string().optional(),
+        },
+        async (args) => {
+          try {
+            const { id, ...patch } = args;
+            const { entry: before } = await getDocumentWithContent(id);
+            await assertDocInScope(ctx, before.projectKey);
+            const entry = await patchDocumentEntry(id, {
+              ...patch,
+              tags: patch.tags === null ? null : patch.tags,
+            });
+            changeEmitter.emit({
+              type: 'doc_updated',
+              sourceId: entry.id,
+              summary: `文档「${entry.title}」已更新`,
+              timestamp: new Date().toISOString(),
+              projectKey: entry.projectKey,
+              agentId: ctx.agentId,
+            });
+            return jsonResult({ ok: true, entry: slimEntry(entry) });
+          } catch (e) {
+            return catchHttp(e);
+          }
+        },
+      ),
+
+      tool(
+        'doc_delete',
+        '删除文档（移除索引与内容文件）。',
+        { id: z.string().min(1) },
+        async ({ id }) => {
+          try {
+            const { entry } = await getDocumentWithContent(id);
+            await assertDocInScope(ctx, entry.projectKey);
+            const title = entry.title;
+            const pk = entry.projectKey;
+            await deleteDocumentEntry(id);
+            changeEmitter.emit({
+              type: 'doc_updated',
+              sourceId: id,
+              summary: `文档「${title}」已删除`,
+              timestamp: new Date().toISOString(),
+              projectKey: pk,
+              agentId: ctx.agentId,
+            });
+            return jsonResult({ ok: true, id });
+          } catch (e) {
+            return catchHttp(e);
+          }
+        },
+      ),
+    ],
+  });
+}
+
+function slimEntry(e: import('@/types').DocEntry) {
+  return {
+    id: e.id,
+    title: e.title,
+    description: e.description,
+    projectKey: e.projectKey,
+    documentKind: e.documentKind ?? 'design_doc',
+    category: e.category,
+    tags: e.tags,
+    status: e.status,
+    fileName: e.fileName,
+    supersedes: e.supersedes,
+    supersededBy: e.supersededBy,
+    createdAt: e.createdAt,
+    updatedAt: e.updatedAt,
+  };
+}

--- a/src/lib/documents-crud.ts
+++ b/src/lib/documents-crud.ts
@@ -1,0 +1,313 @@
+/**
+ * 统一文档域 CRUD — 供 HTTP /api/docs 与进程内 documents MCP 共用。
+ */
+
+import { promises as fs } from 'fs';
+import { getDocumentContentPath, getDocumentsContentDir } from '@/lib/file-store';
+import { readDocsIndexFromDocuments, saveDocsIndexToDocuments } from '@/lib/documents-store';
+import { badRequest, notFound, HttpError } from '@/lib/http-error';
+import { assertDocumentTextWritable, documentTextWriteErrorResponse } from '@/lib/document-text-write-guard';
+import type { DocEntry, DocsIndexData, DocStatus, DocumentKind } from '@/types';
+
+const DEFAULT_INDEX: DocsIndexData = { projects: {} };
+
+export async function readDocsIndex(): Promise<DocsIndexData> {
+  const data = await readDocsIndexFromDocuments();
+  if (data.projects && Object.keys(data.projects).length > 0) {
+    return data;
+  }
+  return DEFAULT_INDEX;
+}
+
+export async function writeDocsIndex(data: DocsIndexData): Promise<void> {
+  await saveDocsIndexToDocuments(data);
+}
+
+export function findDocInIndex(
+  data: DocsIndexData,
+  id: string,
+): { entry: DocEntry; projectKey: string; entries: DocEntry[] } | null {
+  for (const [projectKey, entries] of Object.entries(data.projects)) {
+    const entry = entries.find((e) => e.id === id);
+    if (entry) return { entry, projectKey, entries };
+  }
+  return null;
+}
+
+function filterByDocumentKind(entries: DocEntry[], dk: DocumentKind | null): DocEntry[] {
+  if (!dk) return entries;
+  return entries.filter((e) => (e.documentKind ?? 'design_doc') === dk);
+}
+
+export async function listDocEntries(options: {
+  projectKey?: string;
+  category?: string;
+  tags?: string[];
+  status?: DocStatus | null;
+  documentKind?: DocumentKind | null;
+}): Promise<{ mode: 'by_project' | 'filtered' | 'all_projects'; docs?: DocEntry[]; projects?: Record<string, DocEntry[]> }> {
+  const data = await readDocsIndex();
+  const hasFilters = !!(options.category || (options.tags && options.tags.length > 0) || options.status || options.documentKind);
+
+  if (!hasFilters) {
+    if (options.projectKey) {
+      return { mode: 'by_project', docs: data.projects[options.projectKey] ?? [] };
+    }
+    return { mode: 'all_projects', projects: data.projects };
+  }
+
+  const projectKeys = options.projectKey ? [options.projectKey] : Object.keys(data.projects);
+  const filtered: DocEntry[] = [];
+  for (const pk of projectKeys) {
+    let entries = data.projects[pk] ?? [];
+    entries = filterByDocumentKind(entries, options.documentKind ?? null);
+    for (const entry of entries) {
+      if (options.status) {
+        const docStatus = entry.status ?? 'active';
+        if (docStatus !== options.status) continue;
+      }
+      if (options.category && entry.category !== options.category) continue;
+      if (options.tags && options.tags.length > 0) {
+        const docTags = entry.tags ?? [];
+        if (!options.tags.some((t) => docTags.includes(t))) continue;
+      }
+      filtered.push(entry);
+    }
+  }
+  return { mode: 'filtered', docs: filtered };
+}
+
+export interface CreateDocBody {
+  projectKey: string;
+  title: string;
+  description?: string;
+  content?: string;
+  category?: string;
+  tags?: string[];
+  status?: DocStatus;
+  supersedes?: string;
+  documentKind?: DocumentKind;
+}
+
+export async function createDocumentEntry(body: CreateDocBody): Promise<DocEntry> {
+  const {
+    projectKey,
+    title,
+    description,
+    content,
+    category,
+    tags,
+    status,
+    supersedes,
+    documentKind: bodyDocKind,
+  } = body;
+
+  if (!projectKey?.trim()) throw badRequest('projectKey is required');
+  if (!title?.trim()) throw badRequest('title is required');
+  if (status && !['active', 'draft', 'deprecated'].includes(status)) {
+    throw badRequest('Invalid status. Must be active, draft, or deprecated');
+  }
+  if (tags && !Array.isArray(tags)) throw badRequest('tags must be an array of strings');
+
+  const now = new Date().toISOString();
+  const docId = `doc-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const fileName = `${docId}.md`;
+
+  const documentKind: DocumentKind =
+    bodyDocKind === 'knowledge' ? 'knowledge' : 'design_doc';
+
+  const entry: DocEntry = {
+    id: docId,
+    title: title.trim(),
+    description: description?.trim() || undefined,
+    fileName,
+    projectKey: projectKey.trim(),
+    documentKind,
+    category: category?.trim() || undefined,
+    tags: tags?.length ? tags.map((t: string) => t.trim()).filter(Boolean) : undefined,
+    status: status || undefined,
+    supersedes: supersedes?.trim() || undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await fs.mkdir(getDocumentsContentDir(), { recursive: true });
+  try {
+    assertDocumentTextWritable(title.trim());
+    if (description?.trim()) assertDocumentTextWritable(description);
+    assertDocumentTextWritable(content ?? '');
+    await fs.writeFile(getDocumentContentPath(fileName), content ?? '', 'utf-8');
+  } catch (e) {
+    const enc = documentTextWriteErrorResponse(e);
+    if (enc) throw new HttpError(enc.body.error as string, enc.status);
+    throw e;
+  }
+
+  const data = await readDocsIndex();
+  if (!data.projects[entry.projectKey]) {
+    data.projects[entry.projectKey] = [];
+  }
+  data.projects[entry.projectKey].push(entry);
+
+  if (entry.supersedes) {
+    for (const entries of Object.values(data.projects)) {
+      const oldDoc = entries.find((e) => e.id === entry.supersedes);
+      if (oldDoc) {
+        oldDoc.supersededBy = docId;
+        oldDoc.updatedAt = now;
+        break;
+      }
+    }
+  }
+
+  await writeDocsIndex(data);
+  return entry;
+}
+
+export async function getDocumentWithContent(id: string): Promise<{ entry: DocEntry; content: string }> {
+  const data = await readDocsIndex();
+  const found = findDocInIndex(data, id);
+  if (!found) throw notFound('Doc not found');
+
+  let content = '';
+  try {
+    const readPath = found.entry.sourcePath || getDocumentContentPath(found.entry.fileName);
+    content = await fs.readFile(readPath, 'utf-8');
+  } catch { /* file may not exist */ }
+
+  return { entry: found.entry, content };
+}
+
+export interface PatchDocBody {
+  title?: string;
+  description?: string;
+  category?: string;
+  tags?: string[] | null;
+  status?: DocStatus;
+  content?: string;
+  supersedes?: string;
+  supersededBy?: string;
+}
+
+export async function patchDocumentEntry(id: string, body: PatchDocBody): Promise<DocEntry> {
+  const data = await readDocsIndex();
+  const found = findDocInIndex(data, id);
+  if (!found) throw notFound('Doc not found');
+
+  const { entry } = found;
+  const now = new Date().toISOString();
+
+  try {
+    if (body.title !== undefined && body.title.trim()) assertDocumentTextWritable(body.title.trim());
+    if (body.description !== undefined && body.description?.trim()) {
+      assertDocumentTextWritable(body.description);
+    }
+    if (body.content !== undefined) assertDocumentTextWritable(body.content);
+  } catch (e) {
+    const enc = documentTextWriteErrorResponse(e);
+    if (enc) throw new HttpError(enc.body.error as string, enc.status);
+    throw e;
+  }
+
+  if (body.title !== undefined) entry.title = body.title.trim();
+  if (body.description !== undefined) {
+    entry.description = body.description?.trim() || undefined;
+  }
+  if (body.category !== undefined) {
+    entry.category = body.category?.trim() || undefined;
+  }
+  if (body.tags !== undefined) {
+    if (body.tags === null || (Array.isArray(body.tags) && body.tags.length === 0)) {
+      entry.tags = undefined;
+    } else if (Array.isArray(body.tags)) {
+      entry.tags = body.tags.map((t: string) => t.trim()).filter(Boolean);
+    }
+  }
+  if (body.status !== undefined) {
+    if (body.status && !['active', 'draft', 'deprecated'].includes(body.status)) {
+      throw badRequest('Invalid status');
+    }
+    entry.status = body.status || undefined;
+  }
+
+  if (body.supersedes !== undefined) {
+    const oldSupersedes = entry.supersedes;
+
+    if (oldSupersedes && oldSupersedes !== body.supersedes) {
+      for (const entries of Object.values(data.projects)) {
+        const oldDoc = entries.find((e) => e.id === oldSupersedes);
+        if (oldDoc && oldDoc.supersededBy === id) {
+          oldDoc.supersededBy = undefined;
+          oldDoc.updatedAt = now;
+          break;
+        }
+      }
+    }
+
+    entry.supersedes = body.supersedes?.trim() || undefined;
+
+    if (entry.supersedes) {
+      for (const entries of Object.values(data.projects)) {
+        const targetDoc = entries.find((e) => e.id === entry.supersedes);
+        if (targetDoc) {
+          targetDoc.supersededBy = id;
+          targetDoc.updatedAt = now;
+          break;
+        }
+      }
+    }
+  }
+
+  if (body.supersededBy !== undefined) {
+    entry.supersededBy = body.supersededBy?.trim() || undefined;
+  }
+
+  entry.updatedAt = now;
+
+  if (body.content !== undefined) {
+    const writePath = entry.sourcePath || getDocumentContentPath(entry.fileName);
+    await fs.writeFile(writePath, body.content, 'utf-8');
+  }
+
+  await writeDocsIndex(data);
+  return entry;
+}
+
+export async function deleteDocumentEntry(id: string): Promise<void> {
+  const data = await readDocsIndex();
+  const found = findDocInIndex(data, id);
+  if (!found) throw notFound('Doc not found');
+
+  if (found.entry.supersedes) {
+    for (const entries of Object.values(data.projects)) {
+      const oldDoc = entries.find((e) => e.id === found.entry.supersedes);
+      if (oldDoc && oldDoc.supersededBy === id) {
+        oldDoc.supersededBy = undefined;
+        oldDoc.updatedAt = new Date().toISOString();
+        break;
+      }
+    }
+  }
+  if (found.entry.supersededBy) {
+    for (const entries of Object.values(data.projects)) {
+      const newDoc = entries.find((e) => e.id === found.entry.supersededBy);
+      if (newDoc && newDoc.supersedes === id) {
+        newDoc.supersedes = undefined;
+        newDoc.updatedAt = new Date().toISOString();
+        break;
+      }
+    }
+  }
+
+  try {
+    const delPath = found.entry.sourcePath || getDocumentContentPath(found.entry.fileName);
+    await fs.unlink(delPath);
+  } catch { /* ignore */ }
+
+  const idx = found.entries.findIndex((e) => e.id === id);
+  found.entries.splice(idx, 1);
+  if (found.entries.length === 0) {
+    delete data.projects[found.projectKey];
+  }
+  await writeDocsIndex(data);
+}

--- a/src/server/routes/docs.ts
+++ b/src/server/routes/docs.ts
@@ -1,156 +1,59 @@
 import { Hono } from 'hono';
-import { promises as fs } from 'fs';
-import { getDocumentContentPath, getDocumentsContentDir } from '@/lib/file-store';
-import { readDocsIndexFromDocuments, saveDocsIndexToDocuments } from '@/lib/documents-store';
-import { badRequest, notFound } from '@/lib/http-error';
-import { assertDocumentTextWritable, documentTextWriteErrorResponse } from '@/lib/document-text-write-guard';
-import type { DocEntry, DocsIndexData, DocStatus, CategoryDef, DocumentKind } from '@/types';
+import {
+  readDocsIndex,
+  writeDocsIndex,
+  listDocEntries,
+  createDocumentEntry,
+  getDocumentWithContent,
+  patchDocumentEntry,
+  deleteDocumentEntry,
+} from '@/lib/documents-crud';
+import { HttpError } from '@/lib/http-error';
+import type { DocStatus, CategoryDef } from '@/types';
 
 const app = new Hono();
 
-const DEFAULT_INDEX: DocsIndexData = { projects: {} };
-
-async function readIndex(): Promise<DocsIndexData> {
-  const data = await readDocsIndexFromDocuments();
-  if (data.projects && Object.keys(data.projects).length > 0) {
-    return data;
+app.onError((err, c) => {
+  if (err instanceof HttpError) {
+    return c.json(
+      { error: err.message, ...(err.code ? { code: err.code } : {}) },
+      err.statusCode as 400,
+    );
   }
-  return DEFAULT_INDEX;
-}
-
-async function writeIndex(data: DocsIndexData): Promise<void> {
-  await saveDocsIndexToDocuments(data);
-}
-
-function findEntry(data: DocsIndexData, id: string) {
-  for (const [projectKey, entries] of Object.entries(data.projects)) {
-    const entry = entries.find((e) => e.id === id);
-    if (entry) return { entry, projectKey, entries };
-  }
-  return null;
-}
+  throw err;
+});
 
 // ---------------------------------------------------------------------------
 // /api/docs
 // ---------------------------------------------------------------------------
-
-function filterByDocumentKind(entries: DocEntry[], dk: DocumentKind | null): DocEntry[] {
-  if (!dk) return entries;
-  return entries.filter((e) => (e.documentKind ?? 'design_doc') === dk);
-}
 
 app.get('/', async (c) => {
   const projectKey = c.req.query('project');
   const category = c.req.query('category');
   const tags = c.req.queries('tag') ?? [];
   const status = c.req.query('status') as DocStatus | null;
-  const documentKind = c.req.query('documentKind') as DocumentKind | null;
+  const documentKind = c.req.query('documentKind') as import('@/types').DocumentKind | null;
 
-  const data = await readIndex();
-  const hasFilters = category || tags.length > 0 || status || documentKind;
+  const result = await listDocEntries({
+    projectKey: projectKey ?? undefined,
+    category: category ?? undefined,
+    tags: tags.length ? tags : undefined,
+    status: status || undefined,
+    documentKind,
+  });
 
-  if (!hasFilters) {
-    if (projectKey) {
-      return c.json({ docs: data.projects[projectKey] ?? [] });
-    }
-    return c.json({ projects: data.projects });
+  if (result.mode === 'by_project') {
+    return c.json({ docs: result.docs ?? [] });
   }
-
-  const projectKeys = projectKey ? [projectKey] : Object.keys(data.projects);
-  const filtered: DocEntry[] = [];
-  for (const pk of projectKeys) {
-    let entries = data.projects[pk] ?? [];
-    entries = filterByDocumentKind(entries, documentKind);
-    for (const entry of entries) {
-      if (status) {
-        const docStatus = entry.status ?? 'active';
-        if (docStatus !== status) continue;
-      }
-      if (category && entry.category !== category) continue;
-      if (tags.length > 0) {
-        const docTags = entry.tags ?? [];
-        if (!tags.some((t) => docTags.includes(t))) continue;
-      }
-      filtered.push(entry);
-    }
+  if (result.mode === 'all_projects') {
+    return c.json({ projects: result.projects ?? {} });
   }
-
-  return c.json({ docs: filtered });
+  return c.json({ docs: result.docs ?? [] });
 });
 
 app.post('/', async (c) => {
   const body = await c.req.json();
-  const {
-    projectKey,
-    title,
-    description,
-    content,
-    category,
-    tags,
-    status,
-    supersedes,
-    documentKind: bodyDocKind,
-  } = body;
-
-  if (!projectKey?.trim()) throw badRequest('projectKey is required');
-  if (!title?.trim()) throw badRequest('title is required');
-  if (status && !['active', 'draft', 'deprecated'].includes(status)) {
-    throw badRequest('Invalid status. Must be active, draft, or deprecated');
-  }
-  if (tags && !Array.isArray(tags)) throw badRequest('tags must be an array of strings');
-
-  const now = new Date().toISOString();
-  const docId = `doc-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-  const fileName = `${docId}.md`;
-
-  const documentKind: DocumentKind =
-    bodyDocKind === 'knowledge' ? 'knowledge' : 'design_doc';
-
-  const entry: DocEntry = {
-    id: docId,
-    title: title.trim(),
-    description: description?.trim() || undefined,
-    fileName,
-    projectKey: projectKey.trim(),
-    documentKind,
-    category: category?.trim() || undefined,
-    tags: tags?.length ? tags.map((t: string) => t.trim()).filter(Boolean) : undefined,
-    status: status || undefined,
-    supersedes: supersedes?.trim() || undefined,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  await fs.mkdir(getDocumentsContentDir(), { recursive: true });
-  try {
-    assertDocumentTextWritable(title.trim());
-    if (description?.trim()) assertDocumentTextWritable(description);
-    assertDocumentTextWritable(content ?? '');
-    await fs.writeFile(getDocumentContentPath(fileName), content ?? '', 'utf-8');
-  } catch (e) {
-    const enc = documentTextWriteErrorResponse(e);
-    if (enc) return c.json(enc.body, enc.status);
-    throw e;
-  }
-
-  const data = await readIndex();
-  if (!data.projects[entry.projectKey]) {
-    data.projects[entry.projectKey] = [];
-  }
-  data.projects[entry.projectKey].push(entry);
-
-  if (entry.supersedes) {
-    for (const entries of Object.values(data.projects)) {
-      const oldDoc = entries.find((e) => e.id === entry.supersedes);
-      if (oldDoc) {
-        oldDoc.supersededBy = docId;
-        oldDoc.updatedAt = now;
-        break;
-      }
-    }
-  }
-
-  await writeIndex(data);
+  const entry = await createDocumentEntry(body);
   return c.json({ ok: true, entry });
 });
 
@@ -160,7 +63,7 @@ app.post('/', async (c) => {
 
 app.get('/tags', async (c) => {
   const projectKey = c.req.query('project');
-  const data = await readIndex();
+  const data = await readDocsIndex();
 
   const tagCounts = new Map<string, number>();
   const projectKeys = projectKey ? [projectKey] : Object.keys(data.projects);
@@ -196,7 +99,7 @@ app.post('/batch', async (c) => {
       return c.json({ error: 'action and non-empty ids[] are required' }, 400);
     }
 
-    const data = await readIndex();
+    const data = await readDocsIndex();
     const now = new Date().toISOString();
     const idSet = new Set(ids as string[]);
     let updated = 0;
@@ -277,7 +180,7 @@ app.post('/batch', async (c) => {
         );
     }
 
-    await writeIndex(data);
+    await writeDocsIndex(data);
     return c.json({ ok: true, updated });
   } catch (error) {
     console.error('Batch operation failed:', error);
@@ -291,7 +194,7 @@ app.post('/batch', async (c) => {
 
 app.get('/categories', async (c) => {
   const projectKey = c.req.query('project');
-  const data = await readIndex();
+  const data = await readDocsIndex();
   const categories = data.categories ?? [];
 
   if (projectKey) {
@@ -313,7 +216,7 @@ app.post('/categories', async (c) => {
       return c.json({ error: 'name is required' }, 400);
     }
 
-    const data = await readIndex();
+    const data = await readDocsIndex();
     if (!data.categories) data.categories = [];
 
     const duplicate = data.categories.find(
@@ -335,7 +238,7 @@ app.post('/categories', async (c) => {
     };
 
     data.categories.push(category);
-    await writeIndex(data);
+    await writeDocsIndex(data);
 
     return c.json({ ok: true, category });
   } catch (error) {
@@ -351,7 +254,7 @@ app.post('/categories', async (c) => {
 app.patch('/categories/:id', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json();
-  const data = await readIndex();
+  const data = await readDocsIndex();
   const categories = data.categories ?? [];
   const category = categories.find((cat) => cat.id === id);
 
@@ -385,13 +288,13 @@ app.patch('/categories/:id', async (c) => {
 
   category.updatedAt = new Date().toISOString();
 
-  await writeIndex(data);
+  await writeDocsIndex(data);
   return c.json({ ok: true, category });
 });
 
 app.delete('/categories/:id', async (c) => {
   const id = c.req.param('id');
-  const data = await readIndex();
+  const data = await readDocsIndex();
   const categories = data.categories ?? [];
   const idx = categories.findIndex((cat) => cat.id === id);
 
@@ -412,154 +315,30 @@ app.delete('/categories/:id', async (c) => {
     }
   }
 
-  await writeIndex(data);
+  await writeDocsIndex(data);
   return c.json({ ok: true });
 });
 
 // ---------------------------------------------------------------------------
-// /api/docs/:id  — single doc CRUD (must be last to avoid catching sub-routes)
+// /api/docs/:id  — single doc CRUD (must be last)
 // ---------------------------------------------------------------------------
 
 app.get('/:id', async (c) => {
   const id = c.req.param('id');
-  const data = await readIndex();
-  const found = findEntry(data, id);
-  if (!found) throw notFound('Doc not found');
-
-  let content = '';
-  try {
-    const readPath = found.entry.sourcePath || getDocumentContentPath(found.entry.fileName);
-    content = await fs.readFile(readPath, 'utf-8');
-  } catch { /* file may not exist yet */ }
-
-  return c.json({ entry: found.entry, content });
+  const { entry, content } = await getDocumentWithContent(id);
+  return c.json({ entry, content });
 });
 
 app.patch('/:id', async (c) => {
   const id = c.req.param('id');
   const body = await c.req.json();
-  const data = await readIndex();
-  const found = findEntry(data, id);
-  if (!found) throw notFound('Doc not found');
-
-  const { entry } = found;
-  const now = new Date().toISOString();
-
-  try {
-    if (body.title !== undefined && body.title.trim()) assertDocumentTextWritable(body.title.trim());
-    if (body.description !== undefined && body.description?.trim()) {
-      assertDocumentTextWritable(body.description);
-    }
-    if (body.content !== undefined) assertDocumentTextWritable(body.content);
-  } catch (e) {
-    const enc = documentTextWriteErrorResponse(e);
-    if (enc) return c.json(enc.body, enc.status);
-    throw e;
-  }
-
-  if (body.title !== undefined) entry.title = body.title.trim();
-  if (body.description !== undefined) {
-    entry.description = body.description?.trim() || undefined;
-  }
-  if (body.category !== undefined) {
-    entry.category = body.category?.trim() || undefined;
-  }
-  if (body.tags !== undefined) {
-    if (body.tags === null || (Array.isArray(body.tags) && body.tags.length === 0)) {
-      entry.tags = undefined;
-    } else if (Array.isArray(body.tags)) {
-      entry.tags = body.tags.map((t: string) => t.trim()).filter(Boolean);
-    }
-  }
-  if (body.status !== undefined) {
-    if (body.status && !['active', 'draft', 'deprecated'].includes(body.status)) {
-      throw badRequest('Invalid status');
-    }
-    entry.status = body.status || undefined;
-  }
-
-  if (body.supersedes !== undefined) {
-    const oldSupersedes = entry.supersedes;
-
-    if (oldSupersedes && oldSupersedes !== body.supersedes) {
-      for (const entries of Object.values(data.projects)) {
-        const oldDoc = entries.find((e) => e.id === oldSupersedes);
-        if (oldDoc && oldDoc.supersededBy === id) {
-          oldDoc.supersededBy = undefined;
-          oldDoc.updatedAt = now;
-          break;
-        }
-      }
-    }
-
-    entry.supersedes = body.supersedes?.trim() || undefined;
-
-    if (entry.supersedes) {
-      for (const entries of Object.values(data.projects)) {
-        const targetDoc = entries.find((e) => e.id === entry.supersedes);
-        if (targetDoc) {
-          targetDoc.supersededBy = id;
-          targetDoc.updatedAt = now;
-          break;
-        }
-      }
-    }
-  }
-
-  if (body.supersededBy !== undefined) {
-    entry.supersededBy = body.supersededBy?.trim() || undefined;
-  }
-
-  entry.updatedAt = now;
-
-  if (body.content !== undefined) {
-    const writePath = entry.sourcePath || getDocumentContentPath(entry.fileName);
-    await fs.writeFile(writePath, body.content, 'utf-8');
-  }
-
-  await writeIndex(data);
+  const entry = await patchDocumentEntry(id, body);
   return c.json({ ok: true, entry });
 });
 
 app.delete('/:id', async (c) => {
   const id = c.req.param('id');
-  const data = await readIndex();
-  const found = findEntry(data, id);
-  if (!found) throw notFound('Doc not found');
-
-  if (found.entry.supersedes) {
-    for (const entries of Object.values(data.projects)) {
-      const oldDoc = entries.find((e) => e.id === found.entry.supersedes);
-      if (oldDoc && oldDoc.supersededBy === id) {
-        oldDoc.supersededBy = undefined;
-        oldDoc.updatedAt = new Date().toISOString();
-        break;
-      }
-    }
-  }
-  if (found.entry.supersededBy) {
-    for (const entries of Object.values(data.projects)) {
-      const newDoc = entries.find((e) => e.id === found.entry.supersededBy);
-      if (newDoc && newDoc.supersedes === id) {
-        newDoc.supersedes = undefined;
-        newDoc.updatedAt = new Date().toISOString();
-        break;
-      }
-    }
-  }
-
-  try {
-    const delPath = found.entry.sourcePath || getDocumentContentPath(found.entry.fileName);
-    await fs.unlink(delPath);
-  } catch { /* ignore */ }
-
-  const idx = found.entries.findIndex((e) => e.id === id);
-  found.entries.splice(idx, 1);
-  if (found.entries.length === 0) {
-    delete data.projects[found.projectKey];
-  }
-  await writeIndex(data);
-
+  await deleteDocumentEntry(id);
   return c.json({ ok: true });
 });
 


### PR DESCRIPTION
## Summary
- Shared CRUD helpers for HTTP and MCP.
- New MCP server projectpilot-documents (doc_list/get/create/update/delete).
- Refactor /api docs routes to use documents-crud.

## Stack
PR 1 of 3. After merge, merge **feat/agent-inprocess-mcp-sdk** (PR2), then **feat/remove-save-doc-documents-ui** (PR3), or merge stacked PRs in order.

Made with [Cursor](https://cursor.com)