### PR TITLE
feat(agent): wire in-process todo, registry, and documents MCP into SDK

### DIFF
--- a/src/lib/agent-registry-mcp-server.ts
+++ b/src/lib/agent-registry-mcp-server.ts
@@ -1,0 +1,421 @@
+/**
+ * Agent Chat：共享记忆、并行执行看板、Agent 注册表的进程内 MCP（结构化工具）。
+ * 需 capabilities.registryMcp；待办仍由 projectpilot-todos 负责。
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import {
+  listActiveTasks,
+  listRunningTasks,
+  registerTask,
+  completeTask,
+  failTask,
+  heartbeatTask,
+  pruneTasks,
+  type ActiveTaskAgentType,
+} from '@/lib/active-tasks';
+import {
+  writeMemory,
+  readMemory,
+  listMemories,
+  deleteMemory,
+  pruneExpired,
+} from '@/lib/shared-memory';
+import { listAgents, getAgentById, updateAgent, type AgentMutationInput } from '@/lib/agents-store';
+import type { AgentCapabilities, ProviderId } from '@/types';
+import { DEFAULT_AGENT_CAPABILITIES } from '@/types';
+
+export const AGENT_REGISTRY_MCP_SERVER_KEY = 'projectpilot-registry';
+
+const TOOL_NAMES = [
+  'memory_list',
+  'memory_read',
+  'memory_write',
+  'memory_delete',
+  'memory_prune_expired',
+  'at_list_running',
+  'at_list_all',
+  'at_register',
+  'at_complete',
+  'at_fail',
+  'at_heartbeat',
+  'at_prune_finished',
+  'reg_list_agents',
+  'reg_get_agent',
+  'reg_update_my_agent',
+] as const;
+
+export function getAgentRegistryMcpAllowedToolIds(): string[] {
+  return TOOL_NAMES.map((n) => `mcp__${AGENT_REGISTRY_MCP_SERVER_KEY}__${n}`);
+}
+
+export interface AgentRegistryMcpContext {
+  agentId: string;
+  projectKey?: string;
+  /** 登记并行任务时默认绑定 */
+  sessionId?: string;
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true as const };
+}
+
+const memoryScopeSchema = z.enum(['project', 'global']);
+
+function resolveMemoryProjectKey(
+  ctx: AgentRegistryMcpContext,
+  scope: 'project' | 'global',
+): string | undefined {
+  if (scope === 'global') return undefined;
+  if (!ctx.projectKey?.trim()) {
+    throw new Error('当前会话无项目上下文，无法在 project 范围操作共享记忆，请使用 scope=global');
+  }
+  return ctx.projectKey.trim();
+}
+
+function canMutateActiveTask(taskAgentId: string | undefined, ctxAgentId: string): boolean {
+  return !taskAgentId || taskAgentId === ctxAgentId;
+}
+
+const capabilitiesPatchSchema = z
+  .object({
+    bash: z.boolean().optional(),
+    fileAccess: z.boolean().optional(),
+    web: z.boolean().optional(),
+    subAgent: z.boolean().optional(),
+    skipReview: z.boolean().optional(),
+    todoRead: z.boolean().optional(),
+    exposePromptPath: z.boolean().optional(),
+    dataStore: z.boolean().optional(),
+    registryMcp: z.boolean().optional(),
+    documentsMcp: z.boolean().optional(),
+  })
+  .optional();
+
+export function createAgentRegistryMcpServer(ctx: AgentRegistryMcpContext) {
+  return createSdkMcpServer({
+    name: AGENT_REGISTRY_MCP_SERVER_KEY,
+    version: '0.1.0',
+    tools: [
+      tool(
+        'memory_list',
+        '列出共享记忆。scope=project 需会话有 projectKey；global=仅全局；both=两者（有项目时）。',
+        {
+          scope: z.enum(['project', 'global', 'both']).optional().describe('默认 both（无项目时等同 global）'),
+        },
+        async ({ scope: scopeArg }) => {
+          const scope = scopeArg ?? 'both';
+          try {
+            const pk = ctx.projectKey?.trim();
+            if (scope === 'global') {
+              return jsonResult({ scope: 'global', entries: await listMemories(undefined) });
+            }
+            if (scope === 'project') {
+              const key = resolveMemoryProjectKey(ctx, 'project');
+              return jsonResult({ scope: 'project', projectKey: key, entries: await listMemories(key) });
+            }
+            // both
+            const globalEntries = await listMemories(undefined);
+            if (!pk) {
+              return jsonResult({ global: globalEntries, project: [] as const });
+            }
+            return jsonResult({
+              global: globalEntries,
+              project: await listMemories(pk),
+              projectKey: pk,
+            });
+          } catch (e) {
+            return errorResult(e instanceof Error ? e.message : String(e));
+          }
+        },
+      ),
+
+      tool(
+        'memory_read',
+        '读取一条共享记忆（按 key）。',
+        {
+          key: z.string().min(1),
+          scope: memoryScopeSchema,
+        },
+        async ({ key, scope }) => {
+          try {
+            const pk = resolveMemoryProjectKey(ctx, scope);
+            const entry = await readMemory(key, pk);
+            if (!entry) return errorResult('未找到或已过期');
+            return jsonResult(entry);
+          } catch (e) {
+            return errorResult(e instanceof Error ? e.message : String(e));
+          }
+        },
+      ),
+
+      tool(
+        'memory_write',
+        '写入或覆盖共享记忆。author 默认当前 Agent ID。',
+        {
+          key: z.string().min(1).max(200),
+          value: z.string().max(50_000),
+          scope: memoryScopeSchema,
+          ttlHours: z.number().min(1).max(8760).optional(),
+        },
+        async ({ key, value, scope, ttlHours }) => {
+          try {
+            const pk = resolveMemoryProjectKey(ctx, scope);
+            const entry = await writeMemory({
+              key,
+              value,
+              author: ctx.agentId,
+              projectKey: pk,
+              ...(ttlHours !== undefined ? { ttlHours } : {}),
+            });
+            return jsonResult(entry);
+          } catch (e) {
+            return errorResult(e instanceof Error ? e.message : String(e));
+          }
+        },
+      ),
+
+      tool(
+        'memory_delete',
+        '删除一条共享记忆。',
+        {
+          key: z.string().min(1),
+          scope: memoryScopeSchema,
+        },
+        async ({ key, scope }) => {
+          try {
+            const pk = resolveMemoryProjectKey(ctx, scope);
+            const ok = await deleteMemory(key, pk);
+            return jsonResult({ ok });
+          } catch (e) {
+            return errorResult(e instanceof Error ? e.message : String(e));
+          }
+        },
+      ),
+
+      tool(
+        'memory_prune_expired',
+        '清理所有共享记忆文件中已过期的条目。',
+        {},
+        async () => {
+          const n = await pruneExpired();
+          return jsonResult({ pruned: n });
+        },
+      ),
+
+      tool(
+        'at_list_running',
+        '列出当前并行看板上「运行中且未心跳过期」的任务。',
+        {},
+        async () => {
+          const tasks = await listRunningTasks();
+          return jsonResult({ count: tasks.length, tasks });
+        },
+      ),
+
+      tool(
+        'at_list_all',
+        '列出看板文件中的全部任务记录（含已完成/失败，可能较长）。',
+        {},
+        async () => {
+          const tasks = await listActiveTasks();
+          return jsonResult({ count: tasks.length, tasks });
+        },
+      ),
+
+      tool(
+        'at_register',
+        '登记并行执行任务。agentId/sessionId/projectKey 默认绑定当前会话。',
+        {
+          title: z.string().min(1).max(500),
+          agentType: z.enum(['self-dev', 'task-worker', 'agent-chat']).optional(),
+          scope: z.array(z.string()).optional(),
+          branch: z.string().optional(),
+          todoId: z.string().optional(),
+          sessionId: z.string().optional().describe('默认当前会话；可覆盖'),
+        },
+        async ({ title, agentType, scope, branch, todoId, sessionId }) => {
+          const entry = await registerTask({
+            agentType: (agentType ?? 'agent-chat') as ActiveTaskAgentType,
+            agentId: ctx.agentId,
+            projectKey: ctx.projectKey?.trim() || undefined,
+            title,
+            scope,
+            branch,
+            sessionId: sessionId?.trim() || ctx.sessionId,
+            todoId: todoId?.trim() || undefined,
+          });
+          return jsonResult(entry);
+        },
+      ),
+
+      tool(
+        'at_complete',
+        '将运行中的并行任务标记为完成（仅可操作 agentId 与当前 Agent 一致或未填 agentId 的条目）。',
+        { taskId: z.string().min(1) },
+        async ({ taskId }) => {
+          const tasks = await listActiveTasks();
+          const t = tasks.find((x) => x.id === taskId);
+          if (!t) return errorResult('任务不存在');
+          if (!canMutateActiveTask(t.agentId, ctx.agentId)) {
+            return errorResult('无权操作其他 Agent 登记的任务');
+          }
+          const ok = await completeTask(taskId);
+          return jsonResult({ ok });
+        },
+      ),
+
+      tool(
+        'at_fail',
+        '将运行中的并行任务标记为失败。',
+        { taskId: z.string().min(1) },
+        async ({ taskId }) => {
+          const tasks = await listActiveTasks();
+          const t = tasks.find((x) => x.id === taskId);
+          if (!t) return errorResult('任务不存在');
+          if (!canMutateActiveTask(t.agentId, ctx.agentId)) {
+            return errorResult('无权操作其他 Agent 登记的任务');
+          }
+          const ok = await failTask(taskId);
+          return jsonResult({ ok });
+        },
+      ),
+
+      tool(
+        'at_heartbeat',
+        '更新并行任务心跳时间。',
+        { taskId: z.string().min(1) },
+        async ({ taskId }) => {
+          const tasks = await listActiveTasks();
+          const t = tasks.find((x) => x.id === taskId);
+          if (!t) return errorResult('任务不存在');
+          if (!canMutateActiveTask(t.agentId, ctx.agentId)) {
+            return errorResult('无权操作其他 Agent 登记的任务');
+          }
+          const ok = await heartbeatTask(taskId);
+          return jsonResult({ ok });
+        },
+      ),
+
+      tool(
+        'at_prune_finished',
+        '清理看板中已完成/失败/过期的记录（与 CLI prune 行为一致）。',
+        {},
+        async () => {
+          const removed = await pruneTasks();
+          return jsonResult({ removed });
+        },
+      ),
+
+      tool(
+        'reg_list_agents',
+        '列出 Agent 注册表（默认不含归档、不含 systemPrompt）。',
+        {
+          includeArchived: z.boolean().optional(),
+          projectKey: z.string().optional().describe('按项目过滤；不传则不过滤'),
+        },
+        async ({ includeArchived, projectKey }) => {
+          const agents = await listAgents({
+            includeArchived: !!includeArchived,
+            includePrompts: false,
+            projectKey: projectKey?.trim() || undefined,
+          });
+          const slim = agents.map((a) => ({
+            id: a.id,
+            name: a.name,
+            slug: a.slug,
+            description: a.description,
+            builtIn: a.builtIn,
+            archived: a.archived,
+            projectKey: a.projectKey,
+            capabilities: a.capabilities,
+            defaultProvider: a.defaultProvider,
+            defaultModel: a.defaultModel,
+            triggerHints: a.triggerHints,
+          }));
+          return jsonResult({ count: slim.length, agents: slim });
+        },
+      ),
+
+      tool(
+        'reg_get_agent',
+        '按 id 获取单个 Agent；includePrompt 为 true 时附带解析后的 systemPrompt（可能较长）。',
+        {
+          id: z.string().min(1),
+          includePrompt: z.boolean().optional(),
+        },
+        async ({ id, includePrompt }) => {
+          const agent = await getAgentById(id, {
+            includeArchived: true,
+            includePrompt: !!includePrompt,
+          });
+          if (!agent) return errorResult('Agent 不存在');
+          return jsonResult(agent);
+        },
+      ),
+
+      tool(
+        'reg_update_my_agent',
+        '仅允许更新「当前会话 Agent」（与 ctx.agentId 一致）。capabilities 为部分字段时会与现有能力合并。',
+        {
+          name: z.string().max(200).optional(),
+          description: z.string().max(2000).optional(),
+          systemPrompt: z.string().max(200_000).optional(),
+          icon: z.string().max(80).optional(),
+          capabilities: capabilitiesPatchSchema,
+          defaultModel: z.string().max(200).optional(),
+          defaultProvider: z.string().max(64).optional(),
+          contextStrategy: z.enum(['additive', 'exclusive']).optional(),
+          triggerHints: z.array(z.string()).optional(),
+          promptRefs: z.array(z.string()).optional(),
+        },
+        async (patch) => {
+          const id = ctx.agentId;
+          const existing = await getAgentById(id, { includeArchived: true, includePrompt: false });
+          if (!existing) return errorResult('当前 Agent 在注册表中不存在');
+
+          const input: AgentMutationInput = {};
+
+          if (patch.name !== undefined) {
+            const n = patch.name.trim();
+            if (!n) return errorResult('name 不能为空');
+            input.name = n;
+          }
+          if (patch.description !== undefined) input.description = patch.description;
+          if (patch.systemPrompt !== undefined) input.systemPrompt = patch.systemPrompt;
+          if (patch.icon !== undefined) input.icon = patch.icon;
+          if (patch.defaultModel !== undefined) input.defaultModel = patch.defaultModel;
+          if (patch.defaultProvider !== undefined) {
+            input.defaultProvider = (patch.defaultProvider.trim() || undefined) as ProviderId | undefined;
+          }
+          if (patch.contextStrategy !== undefined) input.contextStrategy = patch.contextStrategy;
+          if (patch.triggerHints !== undefined) input.triggerHints = patch.triggerHints;
+          if (patch.promptRefs !== undefined) input.promptRefs = patch.promptRefs;
+
+          if (patch.capabilities) {
+            const merged: AgentCapabilities = {
+              ...DEFAULT_AGENT_CAPABILITIES,
+              ...(existing.capabilities ?? {}),
+              ...patch.capabilities,
+            };
+            input.capabilities = merged;
+          }
+
+          if (Object.keys(input).length === 0) {
+            return errorResult('未提供任何可更新字段');
+          }
+
+          const updated = await updateAgent(id, input);
+          if (!updated) return errorResult('更新失败');
+          const { systemPrompt: _sp, ...rest } = updated;
+          return jsonResult(rest);
+        },
+      ),
+    ],
+  });
+}

--- a/src/lib/agent-todo-mcp-server.ts
+++ b/src/lib/agent-todo-mcp-server.ts
@@ -1,0 +1,242 @@
+/**
+ * Agent Chat 专用：通过 Claude Agent SDK 进程内 MCP 暴露待办工具，
+ * 避免模型用 Bash/curl 调本地 HTTP（易错、依赖端口与引号转义）。
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { modifyTodosMerged, readTodosMerged } from '@/lib/todo-file-store';
+import { changeEmitter } from '@/lib/change-emitter';
+import type { TodoItem, TodoLifecycle } from '@/types';
+
+export const AGENT_TODO_MCP_SERVER_KEY = 'projectpilot-todos';
+
+const TOOL_NAMES = ['list_todos', 'create_todo', 'update_todo', 'delete_todo'] as const;
+
+/** 供 buildSdkAllowedTools 在受限工具列表中放行 MCP 工具 */
+export function getAgentTodoMcpAllowedToolIds(): string[] {
+  return TOOL_NAMES.map((n) => `mcp__${AGENT_TODO_MCP_SERVER_KEY}__${n}`);
+}
+
+export interface AgentTodoMcpContext {
+  /** 当前会话项目；与 TodoListLoader 一致 */
+  projectKey?: string;
+  /** 当前 Agent id，用于列表过滤与改删权限 */
+  agentId: string;
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function errorResult(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], isError: true as const };
+}
+
+function canAgentModifyTodo(todo: TodoItem, agentId: string): boolean {
+  return !todo.agentId || todo.agentId === agentId;
+}
+
+function filterListedTodos(todos: TodoItem[], ctx: AgentTodoMcpContext, includeDone: boolean): TodoItem[] {
+  let list = includeDone ? [...todos] : todos.filter((t) => t.status !== 'done');
+  if (ctx.projectKey) {
+    list = list.filter((t) => !t.projectKey || t.projectKey === ctx.projectKey);
+  }
+  list = list.filter((t) => !t.agentId || t.agentId === ctx.agentId);
+  return list;
+}
+
+export function createAgentTodoMcpServer(ctx: AgentTodoMcpContext) {
+  return createSdkMcpServer({
+    name: AGENT_TODO_MCP_SERVER_KEY,
+    version: '0.1.0',
+    tools: [
+      tool(
+        'list_todos',
+        '列出当前会话可见的待办（已按项目与 Agent 过滤）。默认不含已完成项；需要时设 includeDone。',
+        {
+          includeDone: z.boolean().optional().describe('为 true 时包含 status=done'),
+        },
+        async ({ includeDone }) => {
+          const data = await readTodosMerged();
+          const list = filterListedTodos(data.todos, ctx, !!includeDone);
+          return jsonResult({ count: list.length, todos: list });
+        },
+      ),
+
+      tool(
+        'create_todo',
+        '新建待办。未指定 agentId 时默认归属当前 Agent；未指定 projectKey 时使用当前会话项目（若有）。',
+        {
+          title: z.string().min(1).max(500),
+          description: z.string().max(5000).optional(),
+          priority: z.enum(['high', 'medium', 'low']).optional(),
+          status: z.enum(['pending', 'in_progress', 'done']).optional(),
+          agentId: z.string().optional(),
+          projectKey: z.string().optional(),
+        },
+        async ({ title, description, priority, status, agentId, projectKey }) => {
+          const validPriorities = ['high', 'medium', 'low'] as const;
+          const validStatuses = ['pending', 'in_progress', 'done'] as const;
+          const todoPriority = priority && validPriorities.includes(priority) ? priority : 'medium';
+          const todoStatus = status && validStatuses.includes(status) ? status : 'pending';
+          const defaultLifecycle: TodoLifecycle =
+            todoStatus === 'in_progress' ? 'active' : todoStatus === 'done' ? 'done' : 'pending';
+
+          const now = new Date().toISOString();
+          const newTodo: TodoItem = {
+            id: `todo-${Date.now()}`,
+            title: title.trim(),
+            description: description?.trim() || undefined,
+            status: todoStatus,
+            priority: todoPriority,
+            agentId: (typeof agentId === 'string' && agentId.trim()) ? agentId.trim() : ctx.agentId,
+            projectKey:
+              (typeof projectKey === 'string' && projectKey.trim())
+                ? projectKey.trim()
+                : (ctx.projectKey?.trim() || undefined),
+            lifecycle: defaultLifecycle,
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          await modifyTodosMerged((d) => ({
+            ...d,
+            todos: [...d.todos, newTodo],
+          }));
+
+          changeEmitter.emit({
+            type: 'todo_changed',
+            sourceId: newTodo.id,
+            summary: `新待办「${newTodo.title}」已创建`,
+            timestamp: now,
+            projectKey: newTodo.projectKey,
+            agentId: newTodo.agentId,
+          });
+
+          return jsonResult(newTodo);
+        },
+      ),
+
+      tool(
+        'update_todo',
+        '按 id 更新待办。仅可修改分配给当前 Agent 或未分配 agent 的条目。',
+        {
+          id: z.string().describe('todo-{timestamp}'),
+          title: z.string().max(500).optional(),
+          description: z.string().max(5000).optional(),
+          status: z.enum(['pending', 'in_progress', 'done']).optional(),
+          priority: z.enum(['high', 'medium', 'low']).optional(),
+          agentId: z.string().optional(),
+          sessionId: z.string().optional(),
+          projectKey: z.string().optional(),
+          dueAt: z.string().optional(),
+          lifecycle: z
+            .enum(['draft', 'pending', 'active', 'stale', 'done', 'archived'])
+            .optional(),
+        },
+        async (patch) => {
+          const { id, ...rest } = patch;
+          if (!id || !/^todo-\d+$/.test(id)) {
+            return errorResult('Invalid todo id');
+          }
+
+          const validLifecycles: TodoLifecycle[] = ['draft', 'pending', 'active', 'stale', 'done', 'archived'];
+          let didPatch = false;
+
+          const afterData = await modifyTodosMerged((data) => {
+            const idx = data.todos.findIndex((t) => t.id === id);
+            if (idx < 0) return data;
+            const t = data.todos[idx];
+            if (!canAgentModifyTodo(t, ctx.agentId)) {
+              return data;
+            }
+
+            didPatch = true;
+            const next: TodoItem = {
+              ...t,
+              ...(rest.title !== undefined && { title: rest.title.trim() }),
+              ...(rest.description !== undefined && { description: rest.description.trim() || undefined }),
+              ...(rest.status !== undefined && { status: rest.status }),
+              ...(rest.priority !== undefined && { priority: rest.priority }),
+              ...(rest.agentId !== undefined && { agentId: rest.agentId || undefined }),
+              ...(rest.sessionId !== undefined && { sessionId: rest.sessionId || undefined }),
+              ...(rest.projectKey !== undefined && { projectKey: rest.projectKey || undefined }),
+              ...(rest.dueAt !== undefined && { dueAt: rest.dueAt || undefined }),
+              ...(rest.lifecycle !== undefined && validLifecycles.includes(rest.lifecycle)
+                ? { lifecycle: rest.lifecycle }
+                : {}),
+              updatedAt: new Date().toISOString(),
+            };
+            const todos = [...data.todos];
+            todos[idx] = next;
+            return { ...data, todos };
+          });
+
+          if (!didPatch) {
+            return errorResult('Todo not found or not allowed for this agent');
+          }
+
+          const updated = afterData.todos.find((t) => t.id === id);
+          if (!updated) {
+            return errorResult('Todo not found or not allowed for this agent');
+          }
+
+          const statusLabel = patch.status ? `状态变为 ${patch.status}` : '已更新';
+          changeEmitter.emit({
+            type: 'todo_changed',
+            sourceId: id,
+            summary: `待办「${updated.title}」${statusLabel}`,
+            timestamp: new Date().toISOString(),
+            projectKey: updated.projectKey,
+            agentId: updated.agentId,
+          });
+
+          return jsonResult(updated);
+        },
+      ),
+
+      tool(
+        'delete_todo',
+        '按 id 删除待办。仅可删除分配给当前 Agent 或未分配 agent 的条目。',
+        {
+          id: z.string().describe('todo-{timestamp}'),
+        },
+        async ({ id }) => {
+          if (!id || !/^todo-\d+$/.test(id)) {
+            return errorResult('Invalid todo id');
+          }
+
+          let title = '';
+          let projectKey: string | undefined;
+          let agentId: string | undefined;
+
+          await modifyTodosMerged((data) => {
+            const t = data.todos.find((x) => x.id === id);
+            if (!t) return data;
+            if (!canAgentModifyTodo(t, ctx.agentId)) return data;
+            title = t.title;
+            projectKey = t.projectKey;
+            agentId = t.agentId;
+            return { ...data, todos: data.todos.filter((x) => x.id !== id) };
+          });
+
+          if (!title) {
+            return errorResult('Todo not found or not allowed for this agent');
+          }
+
+          changeEmitter.emit({
+            type: 'todo_changed',
+            sourceId: id,
+            summary: `待办「${title}」已删除`,
+            timestamp: new Date().toISOString(),
+            projectKey,
+            agentId,
+          });
+
+          return jsonResult({ ok: true, id });
+        },
+      ),
+    ],
+  });
+}

--- a/src/lib/chat-managers/agent-chat-manager.ts
+++ b/src/lib/chat-managers/agent-chat-manager.ts
@@ -447,6 +447,15 @@ class AgentChatManager {
           fastModeOverride: resolvedOpenAIFastMode,
           resumeSessionId,
           cwd,
+          todoMcpContext: effectiveCaps.todoRead
+            ? { projectKey: sessionProjectKey, agentId }
+            : undefined,
+          registryMcpContext: effectiveCaps.registryMcp
+            ? { agentId, projectKey: sessionProjectKey, sessionId }
+            : undefined,
+          documentsMcpContext: effectiveCaps.documentsMcp
+            ? { agentId, projectKey: sessionProjectKey }
+            : undefined,
         });
       })();
 
@@ -571,6 +580,15 @@ class AgentChatManager {
         model: agent.defaultModel,
         resumeSessionId: isResume ? (existingRun?.claudeSessionId ?? diskSession?.claudeSessionId) : undefined,
         cwd,
+        todoMcpContext: agent.capabilities?.todoRead
+          ? { projectKey: guestProjectKey, agentId }
+          : undefined,
+        registryMcpContext: agent.capabilities?.registryMcp
+          ? { agentId, projectKey: guestProjectKey, sessionId: guestSessionId }
+          : undefined,
+        documentsMcpContext: agent.capabilities?.documentsMcp
+          ? { agentId, projectKey: guestProjectKey }
+          : undefined,
       });
       run.runner = runner;
 

--- a/src/lib/chat-managers/agent-runner.ts
+++ b/src/lib/chat-managers/agent-runner.ts
@@ -24,6 +24,9 @@ import { shouldApplyOpenAIFastMode } from '@/lib/openai-fast-mode';
 import { DEFAULT_OPENAI_REASONING_EFFORT, normalizeOpenAIReasoningEffort } from '@/lib/openai-reasoning-effort';
 import { getAppWorkingDir } from '@/lib/app-paths';
 import { buildSdkQueryOptions, buildCodexExecEnv, getEffectiveAuthMode, getProviderScopedModel, getSettings } from '@/lib/settings-manager';
+import type { AgentTodoMcpContext } from '@/lib/agent-todo-mcp-server';
+import type { AgentRegistryMcpContext } from '@/lib/agent-registry-mcp-server';
+import type { AgentDocumentsMcpContext } from '@/lib/agent-documents-mcp-server';
 import type { AgentEvent, AgentCapabilities, ProviderId } from '@/types';
 
 /** 运行时统一输入：正文为 UTF-8 字符串；多模态由 StreamOptions.images 传入 */
@@ -66,6 +69,12 @@ export interface AgentRunnerCreateOptions {
   fastModeOverride?: boolean;
   resumeSessionId?: string;
   cwd?: string;
+  /** 开启 todoRead 时传入，用于注册进程内待办 MCP（仅 Claude Agent SDK 路径） */
+  todoMcpContext?: AgentTodoMcpContext;
+  /** 开启 registryMcp 时传入（共享记忆 / 并行看板 / Agent 注册表 MCP） */
+  registryMcpContext?: AgentRegistryMcpContext;
+  /** 开启 documentsMcp 时传入（设计文档 / 知识文档 MCP） */
+  documentsMcpContext?: AgentDocumentsMcpContext;
 }
 
 // ── Registry ─────────────────────────────────────────────────────────────────
@@ -164,6 +173,9 @@ async function createClaudeAgentRunner(opts: AgentRunnerCreateOptions, cwd: stri
     effortOverride: opts.effortOverride,
     resumeSessionId: opts.resumeSessionId,
     cwd,
+    todoMcpContext: opts.todoMcpContext,
+    registryMcpContext: opts.registryMcpContext,
+    documentsMcpContext: opts.documentsMcpContext,
   });
 
   // Diagnostic: log key SDK options

--- a/src/lib/chat-managers/session-health-guard.ts
+++ b/src/lib/chat-managers/session-health-guard.ts
@@ -147,6 +147,8 @@ async function callClaudeLightweight(prompt: string): Promise<string> {
         todoRead: false,
         exposePromptPath: false,
         dataStore: false,
+        registryMcp: false,
+        documentsMcp: false,
       },
       cwd: getAppWorkingDir(),
     });

--- a/src/lib/resource-loaders/active-tasks-loader.ts
+++ b/src/lib/resource-loaders/active-tasks-loader.ts
@@ -29,7 +29,13 @@ export class ActiveTasksLoader implements ResourceLoader {
       return `| ${t.title} | ${t.agentType} | ${project} | ${scope} | ${branch} | ${elapsed} |`;
     };
 
-    const md = `以下任务正在并行进行中，请注意避免冲突。如果你的任务涉及相同的文件或模块，请谨慎操作。\n\n${tableHeader}\n${tasks.map(toRow).join('\n')}\n`;
+    const md = `以下任务正在并行进行中，请注意避免冲突。如果你的任务涉及相同的文件或模块，请谨慎操作。
+
+**登记/完成/心跳**：若已开启 **注册表 MCP**（\`registryMcp\`），请用 **projectpilot-registry** 的 \`at_register\`、\`at_complete\`、\`at_fail\`、\`at_heartbeat\` 等工具；否则需在 PP 应用代码根用 \`npx tsx src/lib/active-tasks.ts …\`。
+
+${tableHeader}
+${tasks.map(toRow).join('\n')}
+`;
 
     return {
       ref,

--- a/src/lib/resource-loaders/available-agents-loader.ts
+++ b/src/lib/resource-loaders/available-agents-loader.ts
@@ -69,6 +69,7 @@ export class AvailableAgentsLoader implements ResourceLoader {
 - Claude Agent SDK **没有**名为 \`Agent\`、\`InvokeAgent\` 等「一键切换 Agent」的原生工具；若尝试调用会失败。
 - 委派方式：使用 **Bash** 工具，\`cd\` 到下方 **PP 应用代码根**（与当前会话 \`cwd\` 常为业务项目根目录**不是**同一目录），再运行 \`npx tsx src/lib/call-agent.ts ...\`。
 - 若当前 Agent **未开启 Bash**（\`capabilities.bash = false\`），无法执行上述命令，应请用户在界面中**新建会话并切换**到目标 Agent。
+- 若已开启 **注册表 MCP**（\`registryMcp\`），可用 **projectpilot-registry** 的 \`reg_list_agents\` / \`reg_get_agent\` 拉取注册表；**仅可**用 \`reg_update_my_agent\` 修改**当前** Agent 自身配置，不能改其他 Agent。
 
 **PP 应用代码根（用于 call-agent）**：\`${shAppRoot}\`
 

--- a/src/lib/resource-loaders/shared-memory-loader.ts
+++ b/src/lib/resource-loaders/shared-memory-loader.ts
@@ -28,21 +28,18 @@ ${summary}
 
 ### 读写共享记忆
 
+**推荐**：若当前 Agent 已开启 **「注册表 MCP」**（\`registryMcp\`），请使用 MCP 服务器 **projectpilot-registry** 的工具 \`memory_list\` / \`memory_read\` / \`memory_write\` / \`memory_delete\`（\`scope=project|global\`），勿依赖 Bash。
+
+无该能力时可用 CLI（需在 PP 应用代码根执行）：
+
 \`\`\`bash
-# 写入（同 key 会覆盖）
-npx tsx src/lib/shared-memory.ts write --key "键名" --value "内容" [--project <项目key>] [--author "你的名字"] [--ttl <小时数>]
-
-# 读取
+npx tsx src/lib/shared-memory.ts write --key "键名" --value "内容" [--project <项目key>] [--ttl <小时数>]
 npx tsx src/lib/shared-memory.ts read --key "键名" [--project <项目key>]
-
-# 列表
 npx tsx src/lib/shared-memory.ts list [--project <项目key>]
-
-# 删除
 npx tsx src/lib/shared-memory.ts delete --key "键名" [--project <项目key>]
 \`\`\`
 
-**使用建议**：当你发现了对其他 Agent 有价值的信息（如架构决策、调试发现、环境问题等），主动写入共享记忆。临时信息设置 TTL（如 \`--ttl 24\` = 24小时后过期）。
+**使用建议**：当你发现了对其他 Agent 有价值的信息（如架构决策、调试发现、环境问题等），主动写入共享记忆。临时信息设置 TTL（MCP 的 \`ttlHours\` 或 CLI 的 \`--ttl\`）。
 `;
 
     return {

--- a/src/lib/resource-loaders/todo-list-loader.ts
+++ b/src/lib/resource-loaders/todo-list-loader.ts
@@ -16,33 +16,24 @@ const STATUS_LABELS: Record<string, string> = {
   done: '已完成',
 };
 
-const API_GUIDE = `### Todo API
+const MCP_GUIDE = `### 待办操作（优先使用 MCP 工具）
 
-基础 URL: \`http://localhost:4000/api/todos\`
+本会话已注册 MCP 服务器 **projectpilot-todos**（结构化工具调用，勿用 Bash/curl 访问 HTTP）。
 
-| 操作 | 方法 | 路径 | 请求体 |
-|------|------|------|--------|
-| 列表 | GET | /api/todos | — |
-| 新建 | POST | /api/todos | \`{ title, description?, priority?, projectKey? }\` |
-| 更新 | PATCH | /api/todos/:id | \`{ title?, description?, status?, priority?, projectKey? }\` |
-| 删除 | DELETE | /api/todos/:id | — |
+| 工具 | 用途 |
+|------|------|
+| \`list_todos\` | 列出当前会话可见待办（可选 \`includeDone\`） |
+| \`create_todo\` | 新建（\`title\` 必填；\`description\`、\`priority\`、\`status\`、\`agentId\`、\`projectKey\` 可选） |
+| \`update_todo\` | 更新（\`id\` 必填 + 要改的字段） |
+| \`delete_todo\` | 删除（\`id\`） |
 
-字段说明：
-- **status**: \`pending\` / \`in_progress\` / \`done\`
-- **priority**: \`high\` / \`medium\` / \`low\`
-- **id** 格式: \`todo-{timestamp}\`（创建时自动生成）
+**status**: \`pending\` / \`in_progress\` / \`done\`  
+**priority**: \`high\` / \`medium\` / \`low\`  
+**id** 格式: \`todo-{timestamp}\`
 
-使用示例（Bash）:
-\`\`\`bash
-# 标记为进行中
-curl -s -X PATCH http://localhost:4000/api/todos/todo-123 -H "Content-Type: application/json" -d '{"status":"in_progress"}'
+开始处理某条待办时请 \`update_todo\` 将 \`status\` 设为 \`in_progress\`；完成后设为 \`done\`。
 
-# 标记为完成
-curl -s -X PATCH http://localhost:4000/api/todos/todo-123 -H "Content-Type: application/json" -d '{"status":"done"}'
-
-# 新建待办
-curl -s -X POST http://localhost:4000/api/todos -H "Content-Type: application/json" -d '{"title":"…","priority":"high"}'
-\`\`\``;
+（REST \`/api/todos\` 仍供应用前端使用；Agent 侧请只用上述 MCP 工具。）`;
 
 export class TodoListLoader implements ResourceLoader {
   readonly type = 'todo-list' as const;
@@ -66,7 +57,7 @@ export class TodoListLoader implements ResourceLoader {
     if (todos.length === 0) {
       return {
         ref,
-        content: API_GUIDE + '\n\n当前没有未完成的待办事项。',
+        content: MCP_GUIDE + '\n\n当前没有未完成的待办事项。',
         sectionTitle: 'AI 待办系统',
         ok: true,
       };
@@ -82,20 +73,9 @@ export class TodoListLoader implements ResourceLoader {
 
     const todoList = `### 当前待办（共 ${todos.length} 项）\n\n${lines.join('\n\n')}`;
 
-    const STATUS_GUIDE = `### 任务状态管理
-
-当你完成了某个待办任务后，请主动更新其状态：
-\`\`\`bash
-curl -s -X PATCH http://localhost:4000/api/todos/<todo-id> -H "Content-Type: application/json" -d '{"status":"done"}'
-\`\`\`
-如果你开始处理某个待办，先将其标记为进行中：
-\`\`\`bash
-curl -s -X PATCH http://localhost:4000/api/todos/<todo-id> -H "Content-Type: application/json" -d '{"status":"in_progress"}'
-\`\`\``;
-
     return {
       ref,
-      content: API_GUIDE + '\n\n' + todoList + '\n\n' + STATUS_GUIDE,
+      content: MCP_GUIDE + '\n\n' + todoList,
       sectionTitle: 'AI 待办系统',
       ok: true,
     };

--- a/src/lib/settings-manager.ts
+++ b/src/lib/settings-manager.ts
@@ -10,6 +10,24 @@ import { getDataDir, getSettingsPath, readJsonFile, writeJsonFile } from '@/lib/
 import { getKimiCandidateBaseUrls, getProviderPreset } from '@/lib/provider-registry';
 import type { AgentCapabilities, AppSettings, ClaudeAuthMode, ClaudeSettings, CustomProviderConfig, ProviderCredential, ProviderId, ResolvedAiCredential } from '@/types';
 import { DEFAULT_AGENT_CAPABILITIES, DEFAULT_APP_SETTINGS } from '@/types';
+import {
+  AGENT_TODO_MCP_SERVER_KEY,
+  createAgentTodoMcpServer,
+  getAgentTodoMcpAllowedToolIds,
+  type AgentTodoMcpContext,
+} from '@/lib/agent-todo-mcp-server';
+import {
+  AGENT_REGISTRY_MCP_SERVER_KEY,
+  createAgentRegistryMcpServer,
+  getAgentRegistryMcpAllowedToolIds,
+  type AgentRegistryMcpContext,
+} from '@/lib/agent-registry-mcp-server';
+import {
+  AGENT_DOCUMENTS_MCP_SERVER_KEY,
+  createAgentDocumentsMcpServer,
+  getAgentDocumentsMcpAllowedToolIds,
+  type AgentDocumentsMcpContext,
+} from '@/lib/agent-documents-mcp-server';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -508,11 +526,21 @@ export async function buildAgentPermissionArgs(
 
 import type { Options as SdkQueryOptions, PermissionMode as SdkPermissionMode } from '@anthropic-ai/claude-agent-sdk';
 
+/** 与 buildSdkQueryOptions 中注册的进程内 MCP 对应；受限工具模式下需显式列入 allowedTools */
+export type SdkExtraMcpFlags = {
+  todo?: boolean;
+  registry?: boolean;
+  documents?: boolean;
+};
+
 /**
  * 根据 Agent 能力配置构造 SDK allowedTools 列表。
  * 全部开启返回 undefined（不限制），部分开启返回工具名数组。
  */
-export function buildSdkAllowedTools(capabilities: AgentCapabilities | undefined): string[] | undefined {
+export function buildSdkAllowedTools(
+  capabilities: AgentCapabilities | undefined,
+  mcpFlags?: SdkExtraMcpFlags,
+): string[] | undefined {
   const caps = capabilities ?? DEFAULT_AGENT_CAPABILITIES;
   const toolCapKeys = ['bash', 'fileAccess', 'web', 'subAgent'] as const;
   if (toolCapKeys.every(k => caps[k])) return undefined;
@@ -525,6 +553,15 @@ export function buildSdkAllowedTools(capabilities: AgentCapabilities | undefined
   }
   if (caps.subAgent && !caps.fileAccess) {
     allowed.push(...SUBAGENT_READONLY_TOOLS);
+  }
+  if (mcpFlags?.todo) {
+    allowed.push(...getAgentTodoMcpAllowedToolIds());
+  }
+  if (mcpFlags?.registry) {
+    allowed.push(...getAgentRegistryMcpAllowedToolIds());
+  }
+  if (mcpFlags?.documents) {
+    allowed.push(...getAgentDocumentsMcpAllowedToolIds());
   }
   return allowed;
 }
@@ -577,6 +614,12 @@ export async function buildSdkQueryOptions(opts: {
   resumeSessionId?: string;
   cwd?: string;
   maxTurns?: number;
+  /** 与 capabilities.todoRead 同时为真时注册进程内待办 MCP 工具 */
+  todoMcpContext?: AgentTodoMcpContext;
+  /** 与 capabilities.registryMcp 同时为真时注册 projectpilot-registry */
+  registryMcpContext?: AgentRegistryMcpContext;
+  /** 与 capabilities.documentsMcp 同时为真时注册 projectpilot-documents */
+  documentsMcpContext?: AgentDocumentsMcpContext;
 }): Promise<SdkQueryOptions> {
   const settings = await getSettings();
   const claude = settings.claude;
@@ -588,8 +631,34 @@ export async function buildSdkQueryOptions(opts: {
   // Model
   const model = opts.modelOverride ?? getProviderScopedModel(claude, provider);
 
-  // Allowed tools
-  const allowedTools = buildSdkAllowedTools(opts.capabilities);
+  const capsMerged = opts.capabilities ?? DEFAULT_AGENT_CAPABILITIES;
+  const enableTodoMcp = !!capsMerged.todoRead && !!opts.todoMcpContext?.agentId;
+  const enableRegistryMcp = !!capsMerged.registryMcp && !!opts.registryMcpContext?.agentId;
+  const enableDocumentsMcp = !!capsMerged.documentsMcp && !!opts.documentsMcpContext?.agentId;
+
+  // Allowed tools（受限模式下需显式列出 MCP 工具名）
+  const allowedTools = buildSdkAllowedTools(opts.capabilities, {
+    todo: enableTodoMcp,
+    registry: enableRegistryMcp,
+    documents: enableDocumentsMcp,
+  });
+
+  const todoMcpServer = enableTodoMcp && opts.todoMcpContext
+    ? createAgentTodoMcpServer(opts.todoMcpContext)
+    : null;
+
+  const registryMcpServer = enableRegistryMcp && opts.registryMcpContext
+    ? createAgentRegistryMcpServer(opts.registryMcpContext)
+    : null;
+
+  const documentsMcpServer = enableDocumentsMcp && opts.documentsMcpContext
+    ? createAgentDocumentsMcpServer(opts.documentsMcpContext)
+    : null;
+
+  const mcpServers: NonNullable<SdkQueryOptions['mcpServers']> = {};
+  if (todoMcpServer) mcpServers[AGENT_TODO_MCP_SERVER_KEY] = todoMcpServer;
+  if (registryMcpServer) mcpServers[AGENT_REGISTRY_MCP_SERVER_KEY] = registryMcpServer;
+  if (documentsMcpServer) mcpServers[AGENT_DOCUMENTS_MCP_SERVER_KEY] = documentsMcpServer;
 
   // Permission mode
   const { permissionMode, allowDangerouslySkipPermissions } = await buildSdkPermissionMode(opts.capabilities);
@@ -622,6 +691,7 @@ export async function buildSdkQueryOptions(opts: {
     permissionMode,
     ...(allowDangerouslySkipPermissions ? { allowDangerouslySkipPermissions: true } : {}),
     ...(allowedTools ? { allowedTools } : {}),
+    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
     ...(maxTurns && maxTurns > 0 ? { maxTurns } : {}),
     ...(opts.resumeSessionId ? { resume: opts.resumeSessionId } : {}),
     ...(opts.systemPrompt ? {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -413,6 +413,16 @@ export interface AgentCapabilities {
   exposePromptPath: boolean;
   /** Grant agent read/write access to its private workspace (agents/workspaces/{agentId}/) */
   dataStore: boolean;
+  /**
+   * 进程内 MCP：共享记忆、并行看板、Agent 注册表（读全体 / 仅改自身配置）。
+   * 与 todoRead（待办 MCP）独立，可按需分别开启。
+   */
+  registryMcp: boolean;
+  /**
+   * 进程内 MCP：设计文档与知识文档的 list/get/create/update/delete（projectpilot-documents）。
+   * 与待办、注册表 MCP 独立。
+   */
+  documentsMcp: boolean;
 }
 
 export const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
@@ -424,6 +434,9 @@ export const DEFAULT_AGENT_CAPABILITIES: AgentCapabilities = {
   todoRead: false,
   exposePromptPath: true,
   dataStore: false,
+  registryMcp: false,
+  /** 文档域统一走进程内 projectpilot-documents；新 Agent 默认开启 */
+  documentsMcp: true,
 };
 
 export interface Agent {


### PR DESCRIPTION
## Summary
- Register projectpilot-todos, projectpilot-registry, projectpilot-documents when capabilities allow.
- AgentCapabilities: todoRead, registryMcp, documentsMcp (default true for documents).
- Runner and AgentChatManager pass MCP contexts; session health guard disables MCP.
- Loader copy steers agents to MCP instead of Bash/curl.

## Stack
PR 2 of 3. Base: **feat/documents-crud-and-mcp-server** (merge after PR #55). Next: PR 3 removes save-doc UI.

Made with [Cursor](https://cursor.com)