### PR TITLE
fix(cursor): stabilize ProjectPilot MCP in Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,15 @@
 {
   "mcpServers": {
     "project-pilot": {
-      "command": "npx",
-      "args": ["tsx", "mcp-server/index.ts"]
+      "command": "node",
+      "args": [
+        "node_modules/tsx/dist/cli.mjs",
+        "mcp-server/index.ts"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "TSX_TSCONFIG_PATH": "tsconfig.json"
+      }
     }
   }
 }

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -42,6 +42,10 @@
 
 - **`main`** 稳定可发布；**`next`** 日常集成；**`feature/*`** 从 `next` 开、PR → `next`；**`hotfix/*`** 从 `main` 开、PR → `main` 并回灌 `next`。详情 **[`CONTRIBUTING.md`](CONTRIBUTING.md)**；GitHub 保护规则 **[`docs/github-branch-policy.md`](docs/github-branch-policy.md)**。
 
+## Cursor MCP（外部）
+
+- 仓库根 **`.cursor/mcp.json`** 启动 **`project-pilot`** stdio MCP：用 **`node`** + **`node_modules/tsx/dist/cli.mjs`**，并设 **`TSX_TSCONFIG_PATH=tsconfig.json`**（否则 `@/` 解析失败）。若应用仅在 **`develop-static/`** 子目录，路径前缀与 tsconfig 见 **[`docs/cursor-mcp-project-pilot.md`](docs/cursor-mcp-project-pilot.md)**。
+
 ## 数据存储
 
 - 数据布局：本机 `~/.project-pilot/README.md` + **`数据文件夹现状.md`**；仓库内与代码对齐的索引 **[`docs/data-storage.md`](docs/data-storage.md)**（`file-store` 默认 **`~/.project-pilot`**，不再默认 `~/.project-pilot/data/`）。对齐 2026-04-03

--- a/docs/AI_AGENT_KNOWLEDGE_MAP.md
+++ b/docs/AI_AGENT_KNOWLEDGE_MAP.md
@@ -15,6 +15,7 @@
 | **Claude Code** | `develop-static/CLAUDE.md` | Claude | 架构、文档驱动开发、命令 | `MEMORY.md`、本文、`data-storage.md` |
 | **短记忆** | `develop-static/MEMORY.md` | Claude Code 等 | 高密度结论 | `data-storage.md`、本文 |
 | **Cursor 规则** | `.cursor/rules/*.mdc` | Cursor Agent | 沙箱、终端等 | 若涉及数据路径则对齐 `data-storage.md` |
+| **Cursor MCP（PP stdio）** | 仓库根 `.cursor/mcp.json` + `docs/cursor-mcp-project-pilot.md` | Cursor Agent | 外部 MCP 连接 PP 数据；路径与 `TSX_TSCONFIG_PATH`（根目录 vs `develop-static/` 嵌套） | `mcp-server/index.ts`、本文 |
 | **内置 Agent 提示词** | `develop-static/src/data/defaults/builtin-prompts.ts` | 产品内 Butler / Self-Dev 等 | 用户数据路径、能力描述 | **`docs/data-storage.md`（路径事实必须一致）** |
 | **人类 docs 总入口** | `develop-static/docs/README.md` | 人类 + AI | `docs/` 分层与权威关系 | `data-storage.md` |
 | **Git 分支与 GitHub 保护** | `develop-static/docs/github-branch-policy.md` | 维护者 + 贡献者 | `main` / `next` / `feature/*` / `hotfix/*`；Rulesets 清单 | `CONTRIBUTING.md` |
@@ -107,5 +108,6 @@
 | 2026-04-07 | **Hono API 懒挂载**：`src/server/lazy-route.ts` + `index.ts` 对 `/api/*` 子树首包 `import()`（`tsx` 开发态冷启动更快） | `src/server/lazy-route.ts`、`src/server/index.ts`、`MEMORY.md`、本文件 |
 | 2026-04-07 | **社区市场 UI 对标 LobeHub canary**：左侧商店导航（发现/助手/Skills/MCP/模型/服务商）、顶栏搜索（URL `q`）、助手页分类侧栏+排序+卡片网格、`/workspace/community/agent/:identifier` 详情 + `GET /api/community/item/:id`；非助手 Tab 占位；种子条目扩展 `category/author/updatedAt` 等元数据 | `components/community-store/*`、`flows/community/layout.tsx` 与子路由、`App.tsx` 嵌套 `community/*`、`community-catalog-seed.json`、`routes/community.ts`、`messages/zh.json` & `en.json`、`docs/community-marketplace-lobechat-okr.md`、本文件 |
 | 2026-04-07 | **社区商店 Skills + MCP 实装**：`community-skills-seed.json` + `GET/POST /api/community/skills/*`（安装调用 `writeSkillFile`）；`community-mcp-seed.json` + `GET/POST /api/community/mcp/*` 与 `config/mcp-market.json`；`BaseChatManager` 合并市场 MCP 与 `.mcp.json`；发现页与 `/workspace/community/skill|mcp` 列表/详情/安装 | `mcp-market-store.ts`、`base-chat-manager.ts`、`routes/community.ts`、`community-skill-*`、`community-mcp-*`、`data-storage.md`、本文件 |
+| 2026-04-08 | **Cursor 外部 MCP**：`.cursor/mcp.json` 改为 `node` + `tsx/dist/cli.mjs` + `TSX_TSCONFIG_PATH`；文档 `docs/cursor-mcp-project-pilot.md`（根目录布局与 `develop-static/` 嵌套、禁止 `npm run` 污染 stdout） | `.cursor/mcp.json`、`docs/cursor-mcp-project-pilot.md`、`docs/README.md`、`mcp-server/index.ts` 头注释、`MEMORY.md`、本文件 |
 
 （后续变更请继续追加表格行，勿删历史。）

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ docs/
 
 - **分支语义与 GitHub 权限（维护者清单）**：[github-branch-policy.md](./github-branch-policy.md)
 - **贡献者日常流程**：仓库 [`../CONTRIBUTING.md`](../CONTRIBUTING.md)
+- **Cursor 接入 ProjectPilot MCP（路径、`TSX_TSCONFIG_PATH`、嵌套布局）**：[cursor-mcp-project-pilot.md](./cursor-mcp-project-pilot.md)
 
 ### 领域与路线图
 

--- a/docs/cursor-mcp-project-pilot.md
+++ b/docs/cursor-mcp-project-pilot.md
@@ -1,0 +1,100 @@
+# Cursor 中接入 ProjectPilot MCP（`project-pilot`）
+
+本文说明如何在 Cursor 里通过 **stdio MCP** 连接本仓库自带的 `mcp-server`，让外部 Agent 只读访问项目注册表、知识库文档、Todo、Agent 配置、技能与提示词等。
+
+## 配置文件位置
+
+在**仓库根**（含 `mcp-server/`、`package.json`、`docs/` 的那一层）使用：
+
+`.cursor/mcp.json`
+
+（勿与 `develop-static/.gitignore` 所忽略的 **`develop-static/.mcp.json`** 混淆——若你使用带 `develop-static/` 子目录的派生布局，该文件用于可能含密钥的本地 MCP，默认不入库。）
+
+## 布局 A：官方仓库（应用与依赖在仓库根）
+
+与 **GitHub `Kaine665/Project-Pilot`** 的 `next` 线一致：工作区根即 `package.json` 所在目录。
+
+Cursor 对工作区 MCP 的 `args` 路径常以 **`${workspaceFolder}`** 为基准解析；`tsx` 在 **`node_modules`**。同时 `src/lib/*` 使用 **`@/`** 别名，须在子进程里让 tsx 读到 **`tsconfig.json`**（通过 **`TSX_TSCONFIG_PATH`**）。
+
+推荐配置（与仓库内 `.cursor/mcp.json` 一致）：
+
+```json
+{
+  "mcpServers": {
+    "project-pilot": {
+      "command": "node",
+      "args": [
+        "node_modules/tsx/dist/cli.mjs",
+        "mcp-server/index.ts"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "TSX_TSCONFIG_PATH": "tsconfig.json"
+      }
+    }
+  }
+}
+```
+
+## 布局 B：嵌套 `develop-static/`（应用只在子目录）
+
+若你以**外层 monorepo 根**打开 Cursor，而 Node 依赖与 `mcp-server` 在 **`develop-static/`** 下：
+
+- **`args`** 中凡相对仓库根的路径须加前缀 **`develop-static/`**（否则 Cursor 会解析到 **`仓库根/node_modules`**，找不到 `tsx`）。
+- **`TSX_TSCONFIG_PATH`** 设为 **`develop-static/tsconfig.json`**（相对仓库根）。
+
+```json
+{
+  "mcpServers": {
+    "project-pilot": {
+      "command": "node",
+      "args": [
+        "develop-static/node_modules/tsx/dist/cli.mjs",
+        "develop-static/mcp-server/index.ts"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "TSX_TSCONFIG_PATH": "develop-static/tsconfig.json"
+      }
+    }
+  }
+}
+```
+
+修改后请 **Developer: Reload Window**。在 **Settings → MCP** 中确认 `project-pilot` 为已连接（绿）。
+
+## 排错速查
+
+| 现象 | 可能原因 | 处理 |
+|------|----------|------|
+| `Cannot find module '...\Project-Pilot\node_modules\tsx\...'` 且实际装在子目录 | `args` 用了 `./node_modules/...`，被解析到错误根 | 布局 B：改为 `develop-static/node_modules/...` |
+| `Cannot find module '@/lib/file-store'` | 未加载正确的 `tsconfig.json`，`@/*` 未解析 | 设置 `TSX_TSCONFIG_PATH`（见上表两布局） |
+| MCP 面板无 `project-pilot` | 打开的不是含 `.cursor/mcp.json` 的工作区根 | 用**含该文件的目录**作为 Cursor 文件夹 |
+| 不要用 `npm run mcp` 作为 Cursor 的启动命令 | npm 会把 `> project-pilot@...` 等打到 **stdout**，污染 MCP 的 JSON-RPC | 使用 `node` + `tsx/dist/cli.mjs`，或等价的无 npm 横幅启动方式 |
+
+## 本地自检
+
+在**布局 A** 仓库根：
+
+```bash
+npm install
+node node_modules/tsx/dist/cli.mjs mcp-server/index.ts
+```
+
+**布局 B** 在 monorepo 根且带 `TSX_TSCONFIG_PATH=develop-static/tsconfig.json` 时：
+
+```bash
+node develop-static/node_modules/tsx/dist/cli.mjs develop-static/mcp-server/index.ts
+```
+
+（进程会等待 stdio；无立即报错即表示入口与依赖可加载。）
+
+## 能力与实现
+
+工具列表与语义见 `mcp-server/index.ts`（`list_projects`、`list_documents`、`search_documents`、`list_todos`、`list_agents` 等）。
+
+## 变更记录
+
+| 日期 | 摘要 |
+|------|------|
+| 2026-04-08 | 初版：布局 A/B、Cursor 路径解析、`TSX_TSCONFIG_PATH`、禁止 `npm run` 污染 stdout、自检命令 |

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -5,7 +5,9 @@
  *
  * 能力域：Projects · Documents · Todos · Agents · Skills · Prompts（只读）
  *
- * 启动方式: npx tsx mcp-server/index.ts
+ * 本地开发：`npm run mcp` 或 `npx tsx mcp-server/index.ts`（在仓库根、已 `npm install`）。
+ * **Cursor 外部 MCP**：见仓库根 `.cursor/mcp.json` 与 `docs/cursor-mcp-project-pilot.md`
+ * （须 `node` + `tsx/dist/cli.mjs` + `TSX_TSCONFIG_PATH`；勿用 `npm run mcp` 作 Cursor 启动命令，避免污染 stdout）。
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';


### PR DESCRIPTION
## Summary

Stabilizes the **project-pilot** stdio MCP server when Cursor spawns it: fixes broken `tsx` resolution and missing `@/` path-alias resolution, and documents the pitfalls we hit in production.

## Changes

- **`.cursor/mcp.json`**: run `node node_modules/tsx/dist/cli.mjs mcp-server/index.ts` with `cwd: ${workspaceFolder}` and `TSX_TSCONFIG_PATH=tsconfig.json` (instead of `npx tsx …`).
- **`docs/cursor-mcp-project-pilot.md`**: guide for **layout A** (official repo root) vs **layout B** (nested `develop-static/`), Cursor arg resolution, `TSX_TSCONFIG_PATH`, and why **not** to use `npm run mcp` as the MCP command (npm banners on stdout break JSON-RPC).
- **Cross-links**: `docs/README.md`, `MEMORY.md`, `docs/AI_AGENT_KNOWLEDGE_MAP.md`, `mcp-server/index.ts` header.

## Base branch

Targets **`next`** per `CONTRIBUTING.md` / `docs/github-branch-policy.md`.

---

## 中文摘要

- 修正 Cursor 下 MCP 子进程找不到 `tsx`、以及无法解析 `@/` 的问题（通过本地 `tsx` CLI + `TSX_TSCONFIG_PATH`）。
- 新增运维文档，说明官方根目录布局与 `develop-static/` 嵌套布局的差异及排错表。
- 多入口文档已按 `AI_AGENT_KNOWLEDGE_MAP` 约定同步。
