### PR TITLE
feat(sdk): 增强 SDK 能力支持

### DIFF
--- a/src/components/agent-chat/agent-chat-panel.tsx
+++ b/src/components/agent-chat/agent-chat-panel.tsx
@@ -869,6 +869,31 @@ export function AgentChatPanel({
             case 'stream_end':
               // SSE 正常结束；UI 已在 `done` 时 finalize。
               break;
+
+            case 'result_end': {
+              // 会话结果详情：可以显示统计信息（轮次、成本、时长）
+              console.log('[AgentChat] result_end:', {
+                subtype: event.subtype,
+                stopReason: event.stopReason,
+                numTurns: event.numTurns,
+                totalCostUsd: event.totalCostUsd,
+                durationMs: event.durationMs,
+              });
+              // 可以在这里 dispatch 到 store 或显示 toast
+              break;
+            }
+
+            case 'rate_limit': {
+              // 速率限制状态
+              if (event.status === 'rejected') {
+                const resetTime = event.resetsAt ? new Date(event.resetsAt * 1000).toLocaleTimeString() : '未知';
+                console.warn(`[AgentChat] 速率限制，将在 ${resetTime} 恢复`);
+              } else if (event.status === 'allowed_warning') {
+                const utilizationPct = Math.round((event.utilization ?? 0) * 100);
+                console.warn(`[AgentChat] 接近速率限制，已使用 ${utilizationPct}%`);
+              }
+              break;
+            }
           }
         }
 

--- a/src/lib/agent-event-builders.ts
+++ b/src/lib/agent-event-builders.ts
@@ -107,3 +107,37 @@ export function formatCodexTodoSummaryLine(items: CodexTodoItem[]): string {
   if (!items.length) return '';
   return items.map((t) => `${t.completed ? '✓' : '○'} ${t.text}`).join(' · ');
 }
+
+// ── SDK result / rate_limit 事件构造 ─────────────────────────────────────────
+
+/** 会话结果详情事件（来自 SDK result 消息） */
+export function buildResultEnd(params: {
+  subtype: 'success' | 'error_during_execution' | 'error_max_turns' | 'error_max_budget_usd' | 'error_max_structured_output_retries';
+  stopReason: string | null;
+  numTurns: number;
+  totalCostUsd: number;
+  durationMs: number;
+}): AgentEvent {
+  return {
+    type: 'result_end',
+    subtype: params.subtype,
+    stopReason: params.stopReason,
+    numTurns: params.numTurns,
+    totalCostUsd: params.totalCostUsd,
+    durationMs: params.durationMs,
+  };
+}
+
+/** 速率限制状态事件 */
+export function buildRateLimit(params: {
+  status: 'allowed' | 'allowed_warning' | 'rejected';
+  utilization?: number;
+  resetsAt?: number;
+}): AgentEvent {
+  return {
+    type: 'rate_limit',
+    status: params.status,
+    ...(params.utilization != null ? { utilization: params.utilization } : {}),
+    ...(params.resetsAt != null ? { resetsAt: params.resetsAt } : {}),
+  };
+}

--- a/src/lib/sdk-event-adapter.ts
+++ b/src/lib/sdk-event-adapter.ts
@@ -16,6 +16,8 @@ import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { AgentEvent } from '@/types';
 import {
   buildError,
+  buildRateLimit,
+  buildResultEnd,
   buildTextDelta,
   buildThinkingDelta,
   buildTokenUsage,
@@ -90,6 +92,20 @@ export class SdkEventAdapter {
       if (!this.sessionId && msg.session_id) {
         this.sessionId = msg.session_id;
       }
+
+      // 提取完整的 result 信息，发出 result_end 事件
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const msgAny = msg as any;
+      events.push(
+        buildResultEnd({
+          subtype: msg.subtype,
+          stopReason: msg.stop_reason ?? null,
+          numTurns: msgAny.num_turns ?? 0,
+          totalCostUsd: msgAny.total_cost_usd ?? 0,
+          durationMs: msgAny.duration_ms ?? 0,
+        }),
+      );
+
       // 如果是错误结果（error_during_execution 等），emit error event
       if (msg.subtype !== 'success') {
         events.push(buildError(`SDK query ended: ${msg.subtype}`));
@@ -97,7 +113,7 @@ export class SdkEventAdapter {
       // 从 modelUsage 提取精确的累计 token 用量（含跨工具调用的所有轮次）
       // modelUsage 字段使用 camelCase，且包含 contextWindow，是最可靠的数据来源
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const modelUsage = (msg as any).modelUsage as Record<string, { inputTokens?: number; outputTokens?: number; contextWindow?: number }> | undefined;
+      const modelUsage = msgAny.modelUsage as Record<string, { inputTokens?: number; outputTokens?: number; contextWindow?: number }> | undefined;
       if (modelUsage) {
         let inputTokens = 0;
         let outputTokens = 0;
@@ -119,6 +135,22 @@ export class SdkEventAdapter {
         }
       }
       // NOTE: 不在此处 emit done — done 由 AgentChatManager 在 query 迭代结束后统一处理
+      return events;
+    }
+
+    // 处理 rate_limit_event
+    if (msg.type === 'rate_limit_event') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const info = (msg as any).rate_limit_info;
+      if (info) {
+        events.push(
+          buildRateLimit({
+            status: info.status,
+            utilization: info.utilization,
+            resetsAt: info.resetsAt,
+          }),
+        );
+      }
       return events;
     }
 

--- a/src/lib/settings-manager.ts
+++ b/src/lib/settings-manager.ts
@@ -577,6 +577,10 @@ export async function buildSdkQueryOptions(opts: {
   resumeSessionId?: string;
   cwd?: string;
   maxTurns?: number;
+  /** 最大预算（美元），超限返回 error_max_budget_usd */
+  maxBudgetUsd?: number;
+  /** SDK hooks 配置，支持 PreToolUse、PostToolUse 等事件干预 */
+  hooks?: SdkQueryOptions['hooks'];
 }): Promise<SdkQueryOptions> {
   const settings = await getSettings();
   const claude = settings.claude;
@@ -623,6 +627,8 @@ export async function buildSdkQueryOptions(opts: {
     ...(allowDangerouslySkipPermissions ? { allowDangerouslySkipPermissions: true } : {}),
     ...(allowedTools ? { allowedTools } : {}),
     ...(maxTurns && maxTurns > 0 ? { maxTurns } : {}),
+    ...(opts.maxBudgetUsd && opts.maxBudgetUsd > 0 ? { maxBudgetUsd: opts.maxBudgetUsd } : {}),
+    ...(opts.hooks ? { hooks: opts.hooks } : {}),
     ...(opts.resumeSessionId ? { resume: opts.resumeSessionId } : {}),
     ...(opts.systemPrompt ? {
       systemPrompt: opts.systemPrompt,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -388,7 +388,23 @@ export type AgentEvent =
   | { type: 'awaiting_sub_agents' }
   | { type: 'done' }
   /** 流结束信号；前端在 `done` 后已可更新 UI，Transport 层据此关闭连接。 */
-  | { type: 'stream_end' };
+  | { type: 'stream_end' }
+  /** 会话结果详情（来自 SDK result 消息） */
+  | {
+      type: 'result_end';
+      subtype: 'success' | 'error_during_execution' | 'error_max_turns' | 'error_max_budget_usd' | 'error_max_structured_output_retries';
+      stopReason: string | null;
+      numTurns: number;
+      totalCostUsd: number;
+      durationMs: number;
+    }
+  /** 速率限制状态 */
+  | {
+      type: 'rate_limit';
+      status: 'allowed' | 'allowed_warning' | 'rejected';
+      utilization?: number;
+      resetsAt?: number;
+    };
 
 /** @deprecated 历史别名，新代码请用 AgentEvent */
 export type ChatSSEEvent = AgentEvent;


### PR DESCRIPTION
## Summary

- 新增 `result_end` 事件类型，提取 SDK result 消息的完整信息
  - `subtype`: success / error_during_execution / error_max_turns / error_max_budget_usd
  - `stopReason`: 停止原因
  - `numTurns`: 实际轮次
  - `totalCostUsd`: 总成本
  - `durationMs`: 持续时间

- 新增 `rate_limit` 事件类型，支持速率限制状态监控
  - `status`: allowed / allowed_warning / rejected
  - `utilization`: 使用率
  - `resetsAt`: 重置时间

- `buildSdkQueryOptions` 新增参数支持
  - `maxBudgetUsd`: 预算控制
  - `hooks`: SDK hooks 配置

## 修改文件

| 文件 | 改动 |
|------|------|
| `src/types/index.ts` | 新增 `result_end`、`rate_limit` 事件类型 |
| `src/lib/agent-event-builders.ts` | 新增 `buildResultEnd`、`buildRateLimit` 构建器 |
| `src/lib/sdk-event-adapter.ts` | 增强 result 处理，新增 rate_limit_event 处理 |
| `src/lib/settings-manager.ts` | 新增 `maxBudgetUsd`、`hooks` 参数支持 |
| `src/components/agent-chat/agent-chat-panel.tsx` | 新增事件处理 |

## 后续可用

现在可以：
- 根据 `result_end.subtype === 'error_max_budget_usd'` 判断预算超限
- 根据 `result_end.stopReason === 'max_tokens'` 实现自动续写
- 根据 `rate_limit.status === 'rejected'` 显示速率限制警告
- 传入 `maxBudgetUsd` 控制单次会话预算
- 传入 `hooks` 实现工具执行前后的自定义逻辑

这些增强为后续的"部分控制 loop"打下基础，让上层获得更多自主权。

## Test plan

- [x] TypeScript 类型检查通过
- [x] 项目构建成功 (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)