### PR TITLE
docs: ADR-0001 Eval Suite + ADR-0002 多主题任务结构

### DIFF
--- a/docs/design/decisions/0001-agent-eval-suite.md
+++ b/docs/design/decisions/0001-agent-eval-suite.md
@@ -1,0 +1,46 @@
+# ADR-0001: Agent Prompt 回归测试体系（Eval Suite）
+
+- **状态**: Proposed
+- **日期**: 2026-04-08
+
+## 背景
+
+修改 Agent 的 system prompt 或 skill 后，无法确认是否引入回归。当前 PP 无自动化测试，prompt 质量零验证。
+
+核心矛盾：prompt 改动的效果是**运行时**的、情境化的，传统 benchmark 不适用。
+
+## 决策
+
+### 分阶段实现 Eval Suite
+
+#### 阶段 1（优先）：开发者自测 Case
+
+- 目录结构：`~/.project-pilot/evals/{agentId}/cases/`
+- 每个 case 定义 `{ input, expectedBehaviors, rubric }`
+- `expectedBehaviors` 为行为断言（`shouldCallTool`、`shouldContain`、`shouldNotContain`、`shouldDelegateToAgent`）
+- 提供 CLI 命令：用新旧 prompt 分别跑同一组 case，输出 A/B 对比报告
+- Case 来源：**手动积累**——从真实对话中提取做得好/做得差的场景
+
+#### 阶段 2：自动提取 Case
+
+- 从历史对话记录（`agent-chat-sessions.json`）中，让 Judge Agent 自动提取可复用 eval case
+- 好对话 → 正例，差对话 → 反例
+- 补充：从 prompt 规则推导测试场景（规则变更 → 针对变化部分生成 case）
+
+#### 阶段 3：用户自动验证
+
+- 用户修改 prompt 后，系统自动跑相关 case 并展示回归报告
+- 运行时金丝雀：异步 Judge Agent 评估真实对话质量
+- 指标连续低于阈值时，利用已有 `.history/` 自动回退
+
+### 自动生成测试用例的三种方法
+
+1. **历史对话提取**（最实际）：从会话记录中提取核心考验点
+2. **Prompt 规则推导**（变更验证）：解析 prompt 的行为规则，为每条生成场景
+3. **对抗性生成**（找漏洞）：Red Team Agent 尝试触发 Agent 犯错
+
+## 后果
+
+- 每次 prompt 改动有可量化的回归检查
+- Case 库随使用自然增长
+- Judge Agent 复用现有 Agent 架构，无额外基础设施成本

--- a/docs/design/decisions/0002-multi-topic-work-structure.md
+++ b/docs/design/decisions/0002-multi-topic-work-structure.md
@@ -1,0 +1,67 @@
+# ADR-0002: 多主题任务管理数据结构（树 + 引用 → 图）
+
+- **状态**: Proposed
+- **日期**: 2026-04-08
+
+## 背景
+
+Agent 执行复杂项目时涉及多个主题、问题、方案、任务、目标。当前 PP 的 Todo 是**扁平列表**，无法表达：
+
+- 层级分解（目标 → 主题 → 任务）
+- 跨主题依赖（一个任务被多个主题需要）
+- 任务间的阻塞/关联关系
+
+### 数据结构选型分析
+
+| 结构 | 表达力 | Agent 友好度 | 适用场景 |
+|------|--------|-------------|---------|
+| 列表 | 差——丢失关系 | 高——最简单 | 线性步骤 |
+| 树 | 中——强制单一归属 | 高——层次直觉 | 层级分解 |
+| 图 | 高——任意关系 | 低——可能迷路 | 复杂交叉依赖 |
+| 树 + 引用 | 较高——树为主、引用补充 | 较高——兼顾清晰与灵活 | **本项目选择** |
+
+## 决策
+
+### 阶段 1：树 + 引用
+
+主结构为树（层级清晰），跨主题关系用轻量引用补充：
+
+```typescript
+interface WorkNode {
+  id: string;
+  type: 'goal' | 'topic' | 'task' | 'question' | 'decision';
+  title: string;
+  status: 'active' | 'blocked' | 'done' | 'parked';
+
+  // 树结构
+  parentId?: string;
+  children: string[];
+
+  // 跨主题引用（图的部分，但很克制）
+  relatedTo?: Array<{
+    targetId: string;
+    relation: 'depends-on' | 'blocks' | 'related' | 'alternative-to';
+  }>;
+
+  // Agent 上下文
+  assignedAgent?: string;
+  summary?: string;
+  activeContext?: string;
+}
+```
+
+注入 Agent 上下文时生成**聚焦视图**（当前子树 + 相关引用摘要），而非暴露原始数据结构。
+
+### 阶段 2：演进到图
+
+当树 + 引用无法满足需求时（如引用过多、跨主题关系成为主要结构），迁移到完整图结构：
+
+- 数据模型从 `parentId/children` 改为 `edges[]`
+- 上下文注入逻辑加入图遍历（BFS/DFS 从当前焦点向外扩展 N 层）
+- 保持聚焦视图的设计——Agent 看到的始终是裁剪后的局部视图
+
+## 后果
+
+- 树 + 引用阶段实现简单，Agent 容易理解
+- 聚焦视图避免 Agent 在复杂结构中迷失
+- 为后续图结构预留演进路径，数据可平滑迁移

--- a/docs/design/decisions/README.md
+++ b/docs/design/decisions/README.md
@@ -4,4 +4,9 @@
 - 文内建议含：状态（Proposed / Accepted / Deprecated / Superseded）、背景、决策、后果；替代关系写 `Superseded by ADR-NNNN`。
 - 与某迭代强绑定时，在对应 **contract** 里引用 ADR 编号。
 
-暂无条目时可保留本 README；首个决策使用 `0001-....md`。
+## 条目
+
+| 编号 | 标题 | 状态 |
+|------|------|------|
+| [0001](./0001-agent-eval-suite.md) | Agent Prompt 回归测试体系（Eval Suite） | Proposed |
+| [0002](./0002-multi-topic-work-structure.md) | 多主题任务管理数据结构（树 + 引用 → 图） | Proposed |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 合并请求 · Pull Request

## 🌿 目标分支 / Base branch

- [x] 合并到 **`next`**（常规功能、重构、文档；对应 `feature/*`）
- [ ] 合并到 **`main`**（仅 `hotfix/*` 稳定线紧急修复）

---

## 📝 说明 / Description

记录两项架构决策（ADR），来源于关于 Agent 运行模型的讨论：

1. **ADR-0001: Agent Prompt 回归测试体系（Eval Suite）**
   - 分三阶段：开发者自测 Case → 自动提取 Case → 用户自动验证
   - 定义了测试用例自动生成的三种方法（历史提取、规则推导、对抗性生成）

2. **ADR-0002: 多主题任务管理数据结构（树 + 引用 → 图）**
   - 对比列表/树/图/表四种数据结构的适用性
   - 决定先用树 + 引用（清晰且 Agent 友好），之后按需演进到图

同时更新了 `docs/design/decisions/README.md` 的条目索引。

---

## 🎯 改动类型 / Type of change

- [x] 📚 文档

---

## ✅ 自检清单 / Checklist

- [x] 代码符合本项目风格约定
- [x] 已自行审阅改动
- [x] 已更新对应文档（如需要）
- [x] 无新增明显告警

---

## 🧪 测试说明 / Testing

纯文档变更，无代码改动，无需测试。

---

## 📝 备注 / Additional notes

这两个 ADR 均为 Proposed 状态，记录讨论中的架构方向。后续实现时会将状态更新为 Accepted。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce3c6c93-7b32-4135-88a0-ccbbc19faaee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce3c6c93-7b32-4135-88a0-ccbbc19faaee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

