### PR TITLE
docs: conversation agent system lens and AI entry wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,11 @@ npm run lint         # ESLint 检查
 - 代码中变量名/函数名用英文
 - Commit 消息用英文，遵循 Conventional Commits
 
+## 文档（改 Agent / 会话前先读）
+
+- **对话与 Agent 系统八层对标**（Claude Code / Hermes / OpenHarness vs PP）：[`docs/design/conversation-agent-system-lens.md`](docs/design/conversation-agent-system-lens.md)
+- **多 AI 入口与同步清单**：[`docs/AI_AGENT_KNOWLEDGE_MAP.md`](docs/AI_AGENT_KNOWLEDGE_MAP.md)
+
 ## 关键文件索引
 
 | 路径 | 作用 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,11 @@
 
 ### 域索引
 
-
 | 能力域                     | as-is                            | design                                           |
 | ----------------------- | -------------------------------- | ------------------------------------------------ |
 | Agents 工作区（布局/侧栏/会话）    | `docs/as-is/agents-workspace.md` | `docs/design/agents-workspace.md`                |
+| 对话与 Agent 系统（分层对标、外部参考） | `docs/agent-chat-architecture.md` | `docs/design/conversation-agent-system-lens.md` |
 | 产品定位 / 系统架构 / Dashboard | —                                | `docs/design/product-direction-and-dashboard.md` |
-
 
 > 随项目演进补充更多行。未覆盖的域：先检查 `docs/as-is/` 和 `docs/design/` 是否已有对应页面；若无，改动后创建。
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,8 @@
 
 **产品定位（唯一口径）**：Builder 的 AI 工作台 — 让 AI 对项目越来越懂，而不是每次从零开始；覆盖 Builder 多维度工作（不止代码）。叙事为五模块飞轮（Memory → Loader → Runtime → Distiller → Dashboard）+ 六维度（工程 / 产品 / 设计 / 商业 / 增长 / 运营）+ Dashboard；详见 [`docs/design/product-direction-and-dashboard.md`](docs/design/product-direction-and-dashboard.md)，边界对照见 [`docs/design/product-boundary.md`](docs/design/product-boundary.md)。
 
+**对话 / Agent 会话（架构对标，改 Chat 或 Runner 前先读）**：[`docs/design/conversation-agent-system-lens.md`](docs/design/conversation-agent-system-lens.md)
+
 ---
 
 ## 统一文档系统（设计文档 + 知识文档）

--- a/docs/AI_AGENT_KNOWLEDGE_MAP.md
+++ b/docs/AI_AGENT_KNOWLEDGE_MAP.md
@@ -6,6 +6,10 @@
 
 **本文是仓库内「AI 应读哪些文档、改什么要联动哪里」的权威索引。** 人类或任一 AI 在变更项目级事实（路径、架构、工作流）时，应先打开本文，按检查清单更新相关入口。
 
+### 对话与 Agent 系统（进入本仓库请先读）
+
+凡涉及 **Agent Chat、会话生命周期、Runner、上下文装载、与外部 Agent 运行时对标**，在细读 `agent-chat-architecture` 与 as-is 之前，应先建立**统一分层语言**：[`docs/design/conversation-agent-system-lens.md`](./design/conversation-agent-system-lens.md)（八层模型 + Claude Code harness / Hermes Agent / OpenHarness 与 ProjectPilot 对照）。
+
 ## 多入口一览（须相互感知）
 
 
@@ -35,6 +39,7 @@
 | 数据目录与路径函数 | [`data-storage.md`](./data-storage.md) |
 | 数据规范索引 | [`data-spec/README.md`](./data-spec/README.md) |
 | Agent Chat 架构 | [`agent-chat-architecture.md`](./agent-chat-architecture.md) |
+| **对话与 Agent 系统（八层对标）** | [`design/conversation-agent-system-lens.md`](./design/conversation-agent-system-lens.md) |
 | 统一文档（设计 + 知识） | [`context-system.md`](./context-system.md) |
 | 产品定位 / 五模块飞轮 / Dashboard / 数据模型 | [`design/product-direction-and-dashboard.md`](./design/product-direction-and-dashboard.md) |
 | Git 分支策略与 GitHub 权限（维护者） | [`github-branch-policy.md`](./github-branch-policy.md) |
@@ -124,5 +129,6 @@
 | 2026-04-12 | **产品叙事唯一口径**：README / `product-boundary` / `MEMORY` / `CLAUDE` 与 `product-direction-and-dashboard` 对齐 — Builder 工作台 + 五模块飞轮（含 Dashboard）+ 六维度；删除旧「任务推进系统 / Not another chatbox」类对外定位表述 | `README.md`、`docs/design/product-boundary.md`、`MEMORY.md`、`CLAUDE.md`、本文件 |
 | 2026-04-12 | **MCP 默认市场**：`config/mcp-market.json` 首次缺失时写入 `default-mcp-market.json`（Memory、Sequential Thinking、Playwright）；`listMcpMarketServerKeys` / Agent spawn 前调用 `ensureDefaultMcpMarketSeeded`；`/workspace/mcp` 页改为短说明 | `src/data/default-mcp-market.json`、`mcp-market-store.ts`、`base-chat-manager.ts`、`server/index.ts`、`flows/mcp/page.tsx`、`messages/zh.json`、`messages/en.json`、`data-storage.md`、本文件 |
 | 2026-04-12 | **Cursor Paper MCP**：`.cursor/mcp.json` 增加 `paper`（`npx -y mcp-remote http://127.0.0.1:29979/mcp`）；`docs/cursor-mcp-project-pilot.md` 增补前置条件与排错；知识地图 Cursor MCP 行合并 Paper 说明 | `.cursor/mcp.json`、`docs/cursor-mcp-project-pilot.md`、本文件「多入口一览」表 |
+| 2026-04-14 | **对话与 Agent 系统八层对标**：Claude Code harness / Hermes / OpenHarness 与 PP 映射；`AI_AGENT_KNOWLEDGE_MAP` 入口、`CLAUDE.md` 域索引、`MEMORY.md` 速记、`docs/design/README` | [`docs/design/conversation-agent-system-lens.md`](./design/conversation-agent-system-lens.md)、`docs/AI_AGENT_KNOWLEDGE_MAP.md`、`CLAUDE.md`、`MEMORY.md`、`docs/design/README.md`、`docs/README.md` |
 
 （后续变更请继续追加表格行，勿删历史。）

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ docs/
 
 ### 领域与路线图
 
+- **对话与 Agent 系统（八层对照：Claude Code / Hermes / OpenHarness vs PP）**：[design/conversation-agent-system-lens.md](./design/conversation-agent-system-lens.md)（AI 入口亦见 [`AI_AGENT_KNOWLEDGE_MAP.md`](./AI_AGENT_KNOWLEDGE_MAP.md)）
 - **领域概念模型**：[领域与数据.md](./领域与数据.md)（Scope / Execution / Trigger / Resource / Tracking）
 - **实施路线图（任务总控 + 设计卡）**：[roadmap.md](./roadmap.md) + [`roadmap/`](./roadmap/)
 - **Google 账号与云端同步范围（可选同步、凭据优先）**：[design/google-account-cloud-sync-scope.md](./design/google-account-cloud-sync-scope.md)

--- a/docs/agent-chat-architecture.md
+++ b/docs/agent-chat-architecture.md
@@ -2,9 +2,9 @@
 
 > 关联：`src/lib/chat-managers/agent-chat-manager.ts`、`src/server/routes/agent-chat.ts`、`src/components/agent-chat/agent-chat-panel.tsx`
 >
-> 更新时间：2026-04-05
+> 更新时间：2026-04-14
 >
-> **参见**：[供应商/模型/SDK 支持关系](./provider-model-support.md)
+> **参见**：[供应商/模型/SDK 支持关系](./provider-model-support.md) · [对话与 Agent 系统八层对标（设计）](./design/conversation-agent-system-lens.md)
 
 ---
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,6 +11,7 @@
 
 | 文档 | 主题 |
 |------|------|
+| [conversation-agent-system-lens.md](./conversation-agent-system-lens.md) | **对话与 Agent 系统八层对照**（Claude Code / Hermes / OpenHarness vs PP；Agent 进入仓库先读） |
 | [agents-workspace.md](./agents-workspace.md) | Agents 工作区信息架构与体验原则 |
 | [brainstorm-paper-frontend-design-workflow.md](./brainstorm-paper-frontend-design-workflow.md) | **Brainstorm/轻量 PRD → Paper → `frontend-design`** 联合工作流（防蛮干） |
 | [tasks-hub-information-architecture.md](./tasks-hub-information-architecture.md) | **任务**聚合壳（三子页）IA + Layer 1，供 Paper/改版对照 |

--- a/docs/design/conversation-agent-system-lens.md
+++ b/docs/design/conversation-agent-system-lens.md
@@ -1,0 +1,99 @@
+# 对话与 Agent 系统：八层对照视角
+
+> **用途**：给产品 / 架构 / 实现讨论提供**统一分层语言**，并对照业界三类实现（Claude Code harness、Hermes Agent、OpenHarness）与 ProjectPilot（PP）的差异。  
+> **性质**：`design` — 原则与对照框架；实现细节与入口以 `docs/as-is/agents-workspace.md`、`docs/agent-chat-architecture.md` 为准。  
+> **last_reviewed**: 2026-04-14
+
+---
+
+## 1. 为什么需要「八层」
+
+「对话功能好不好」容易被拆成零散需求（流式、记忆、子代理…）。八层把**会话面、状态、循环、上下文、工具、并行、观测、学习**拆开，便于：
+
+- 对标外部项目时，知道比的是**哪一层**，避免拿 A 的 UI 去比 B 的循环实现；
+- 改 PP 时，判断应**上浮到 Hono**、**留在 SDK**、还是**做新数据面**（见第 4 节与 PP 映射）。
+
+---
+
+## 2. 八层定义（每层回答什么）
+
+| 层 | 代号 | 回答的问题 |
+|----|------|------------|
+| 1 | **Transport / UI** | 用户在哪说话：Web、终端、Telegram…；中断、重试、流式展示 |
+| 2 | **Session 身份与持久化** | `session` 的边界、存哪、恢复、多设备是否同一逻辑会话 |
+| 3 | **Agent loop（回合循环）** | 谁持有 `while`：本进程自写循环，还是外包给 SDK / 子进程 |
+| 4 | **上下文工程** | 系统提示、项目记忆、附件、压缩、token 预算、模型元数据 |
+| 5 | **工具与权限** | 工具定义、执行、并发、审批、沙箱、生命周期 hook |
+| 6 | **子代理 / 并行** | Task、worktree、回合间注入（steering）、多工作流 |
+| 7 | **可观测与治理** | 用量、成本、审计、评测、CI 无人值守模式 |
+| 8 | **纵向学习（跨会话）** | 技能沉淀、记忆检索、用户建模、聊完是否写回项目记忆 |
+
+评价「对话系统」时，按层勾选：**哪层是 PP 必须自研、哪层可委托给 Claude Agent SDK / Codex SDK**。
+
+---
+
+## 3. 三个外部参考项目（如何分层）
+
+以下仓库为**外部开源对照**，路径以官方 Git 为准；本地克隆仅作个人阅读，不进本仓库子模块。
+
+### 3.1 Claude Code harness（Anthropic 系运行时本体）
+
+- **典型形态**：`QueryEngine` + `query.ts` 中大循环；流式工具执行、终止条件（无 tool / maxTurns / budget / hook / abort）同源可见。
+- **强项层**：3（循环）、4（CLAUDE.md / 自动记忆 / session memory / compact）、5（权限栈、Bash 校验、沙箱、MCP 与内置工具同链）、6（AgentTool、fork、worktree、Swarm 等）。
+- **弱项（对 PP 而言）**：与 PP **产品形态不同**（终端/IDE 一体）；若要像素级抄能力，等于绑定其发布节奏与进程模型。
+- **本仓库内延伸阅读**： harness 行为拆解见 `docs/claude-code-harness-study-notes.md`（基于社区可读的 harness 源码笔记）；PP 实际调用链见 `docs/agent-chat-architecture.md`（`query()` 与子进程 JSONL）。
+
+**一句话**：**自研 Agent OS 的完整参考**；PP 通过 **Claude Agent SDK** 间接使用其能力栈的大部分。
+
+### 3.2 Hermes Agent（`https://github.com/NousResearch/hermes-agent`）
+
+- **典型形态**：**网关**（CLI / Telegram / Discord / Slack…）与 **`run_agent` / `AIAgent`** 核心分离；多通道会话状态、打断、流式批处理在 gateway 层大量工程化。
+- **强项层**：1–2（多会话面与连续性）、3（Python 自研循环 + 多厂商适配）、4（`prompt_builder`、`context_compressor`、`model_metadata` 等模块边界清晰）、**8（学习闭环：技能自演进、会话检索、用户建模等，产品叙事强）**。
+- **一句话**：**多入口 + 长生命周期 + 显式上下文管线 + 跨会话学习**；适合对标「会话平台化」与「聊完变聪明」，而非仅 Web 内嵌聊天。
+
+### 3.3 OpenHarness（`https://github.com/AgentBoardTT/openharness`，PyPI 名 `harness-agent`）
+
+- **典型形态**：`harness.core.engine.run()` 组装 **Provider + ToolManager + Session + PermissionManager + hooks + MCP + steering + sandbox** → **`AgentLoop`**（`user → model → tools → …` 全在本仓库 Python 内）。
+- **强项层**：**模块化边界**（3/4/5/6 分包清晰）、**steering**（回合间注入用户消息）、7（eval / audit / observability 目录存在）。
+- **一句话**：**可嵌入的教科书式循环**；适合对标「若 PP 要在服务端显式掌控循环与策略，模块应如何切」。
+
+---
+
+## 4. ProjectPilot 的映射（与飞轮的关系）
+
+| 层 | PP 现状（概括） | 与五模块飞轮的近似关系 |
+|----|----------------|------------------------|
+| 1 | Web `AgentChatPanel` + SSE；工作区壳与侧栏 | 偏 **Dashboard / 工作区** 呈现 |
+| 2 | 会话落盘、列表、分叉、归档等（见 as-is） | **Memory** 的「会话实例」载体，非长期知识本身 |
+| 3 | **Claude `query()` / Codex SDK** 持有主循环；`AgentChatManager` 编排启动与事件适配 | **Runtime** 主体在 SDK；PP 做编排 |
+| 4 | ResourceRegistry、prompt 文件、skills、运行时副本等 | **Loader** + 部分 **Memory** 输入 |
+| 5 | 大量在 SDK/CLI；PP 有危险命令检测、设置与 UI | 安全与体验在 PP 与 SDK 间**分工** |
+| 6 | Task/worktree 等另一条执行线；Chat 内子代理能力相对轻 | **Runtime** 扩展，与 Chat 深度可继续设计 |
+| 7 | 应用内为主；评测/审计非核心 | 可随企业需求增强 |
+| 8 | 架构上 **Distiller 仍缺**（见根 `CLAUDE.md` 飞轮表） | **Distiller** 空白 = 纵向学习缺口 |
+
+**设计结论（可重复引用）**：
+
+- PP 是 **「强工作区 + 会话管理 + 资源注入」包在商用 Agent 运行时外」**；对标 Claude Code **本体**时，应清楚哪些行为在 **SDK 黑盒** 内、哪些必须在 **PP 文档与 as-is** 里写清。
+- 若产品要向 **Hermes** 靠拢，优先投资 **1–2（多面与会话连续性）** 与 **8（沉淀闭环）**，而不是先自研整套 tool loop。
+- 若要向 **OpenHarness** 靠拢，优先把 **3–5 的策略**（压缩、权限回调、steering 语义）在 **Hono 与类型事件** 上**显式化**、可测试。
+
+---
+
+## 5. 相关文档（必读顺序建议）
+
+| 顺序 | 文档 | 作用 |
+|------|------|------|
+| 1 | `docs/AI_AGENT_KNOWLEDGE_MAP.md` | 多入口同步与总索引 |
+| 2 | `docs/agent-chat-architecture.md` | PP Agent Chat 数据流与 Runner 约束 |
+| 3 | `docs/as-is/agents-workspace.md` | 工作区 UI 与会话列表现状 |
+| 4 | `docs/design/agents-workspace.md` | 工作区原则与目标态 |
+| 5 | `docs/claude-code-harness-study-notes.md` | Claude Code harness 能力拆解（只读参考） |
+
+---
+
+## 6. 修订记录
+
+| 日期 | 摘要 |
+|------|------|
+| 2026-04-14 | 初版：八层模型 + 三外部项目对照 + PP 映射与读序 |


### PR DESCRIPTION
## Summary

Adds `docs/design/conversation-agent-system-lens.md`: an eight-layer framework for comparing conversation/agent systems (Claude Code harness, Hermes Agent, OpenHarness) with ProjectPilot, plus where to read next.

## Entry points (per `docs/AI_AGENT_KNOWLEDGE_MAP.md` checklist)

- `docs/AI_AGENT_KNOWLEDGE_MAP.md`: short "read first" subsection + doc index row + changelog row
- `CLAUDE.md`: domain index row
- `MEMORY.md`: one-line pointer for Claude Code
- `docs/README.md`, `docs/design/README.md`, `AGENTS.md`, `docs/agent-chat-architecture.md`: cross-links

## Notes

- Branch rebased on latest `next`; resolved merge conflicts with upstream `CLAUDE.md`, `MEMORY.md`, and changelog table in the knowledge map.

Please review and merge into `next` when ready.

Made with [Cursor](https://cursor.com)