### PR TITLE
fix(electron): pass client dist to Hono; PR CI version + run suffix

### DIFF
--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -1,5 +1,5 @@
 # PR 针对 next：并行构建 Windows + macOS → 本仓库 PR 自动建 **预发布 Release**。
-# 版本号：合并基线 `package.json` 的 **patch + 1** 再拼 **-pr.<PR号>**（脚本 `scripts/ci-compute-pr-desktop-version.mjs`），写入 electron-builder；Release **标题与 tag 同该字符串**（与正式 `v*` 区分）。多附件 + Artifact。
+# 版本号：`ci-compute-pr-desktop-version.mjs` — 合并基线 **patch+1** + `-pr.<PR>` + 可选 **.<GITHUB_RUN_NUMBER>**（每次 workflow 跑递增）；Release 标题与 tag 同该串。多附件 + Artifact。
 # 每个新 PR 一条新 Release；同一 PR 反复推送会先删掉 `*-pr.<N>` 旧预发布再重建。正式发版仍走 release.yml。Fork PR 不写 Release。
 name: PR Desktop Build
 
@@ -38,9 +38,11 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Compute PR desktop app version (patch +1 + -pr.<N>)
+      - name: Compute PR desktop app version (patch +1 + -pr.<N>.<run>)
         id: ci_ver
         shell: bash
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           V=$(node scripts/ci-compute-pr-desktop-version.mjs "${{ github.event.pull_request.number }}")
           echo "version=$V" >> "$GITHUB_OUTPUT"
@@ -87,9 +89,11 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Compute PR desktop app version (patch +1 + -pr.<N>)
+      - name: Compute PR desktop app version (patch +1 + -pr.<N>.<run>)
         id: ci_ver
         shell: bash
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           V=$(node scripts/ci-compute-pr-desktop-version.mjs "${{ github.event.pull_request.number }}")
           echo "version=$V" >> "$GITHUB_OUTPUT"
@@ -138,6 +142,8 @@ jobs:
       - name: Compute PR desktop app version (same as build jobs)
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: appver
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           V=$(node scripts/ci-compute-pr-desktop-version.mjs "${{ github.event.pull_request.number }}")
           echo "version=$V" >> "$GITHUB_OUTPUT"
@@ -149,14 +155,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR="${{ github.event.pull_request.number }}"
-          TAGS=$(gh release list --limit 200 --json tagName | jq -r --arg pr "$PR" '.[] | .tagName | select(endswith("-pr." + $pr))')
-          if [ -z "$TAGS" ]; then echo "No prior PR prereleases for #${PR}"; exit 0; fi
-          echo "$TAGS" | while IFS= read -r tag; do
+          found=0
+          while IFS= read -r tag; do
             [ -z "$tag" ] && continue
+            [[ "$tag" =~ -pr\.${PR}(\.[0-9]+)*$ ]] || continue
+            found=1
             echo "Deleting release/tag: ${tag}"
             gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
             gh api --method DELETE "repos/${{ github.repository }}/git/refs/tags/${tag}" 2>/dev/null || true
-          done
+          done < <(gh release list --limit 200 --json tagName | jq -r '.[].tagName')
+          [ "$found" -eq 0 ] && echo "No prior PR prereleases for #${PR}"
 
       - name: Download Windows + macOS artifacts
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -175,7 +183,7 @@ jobs:
           body: |
             **PR #${{ github.event.pull_request.number }}** 自动桌面构建（**预发布**，非正式版本）。
 
-            - **软件版本**（合并基线 `package.json` 的 **patch + 1** 并加 `-pr.<PR>`）：`${{ steps.appver.outputs.version }}`
+            - **软件版本**（基线 **patch+1** + `-pr.<PR>.<run>`，见 `ci-compute-pr-desktop-version.mjs`）：`${{ steps.appver.outputs.version }}`
             - **Git tag** 同上（与正式发版 `v*` tag 区分）
             - **合并验证提交**：`${{ github.sha }}`（`pull_request` 默认 merge commit）
             - 工作流：[`.github/workflows/pr-desktop-build.yml`](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.base.ref }}/.github/workflows/pr-desktop-build.yml)

--- a/electron/server.ts
+++ b/electron/server.ts
@@ -23,15 +23,38 @@ export function startBackendServer(port: number): Promise<ChildProcess> {
       return;
     }
 
+    /** 与 `package.json` asarUnpack 对齐；主进程路径可靠，避免子进程 bundle 里 `__dirname` 与磁盘不一致导致找不到 `dist/client` → 整页 404 */
+    let projectPilotClientDist = '';
+    if (resourcesPath) {
+      const unpackedClient = path.join(resourcesPath, 'app.asar.unpacked', 'dist', 'client');
+      const asarClient = path.join(resourcesPath, 'app.asar', 'dist', 'client');
+      if (fs.existsSync(path.join(unpackedClient, 'index.html'))) {
+        projectPilotClientDist = unpackedClient;
+      } else if (fs.existsSync(path.join(asarClient, 'index.html'))) {
+        projectPilotClientDist = asarClient;
+      }
+    }
+    if (!projectPilotClientDist) {
+      const localClient = path.resolve(__dirname, '../dist/client');
+      if (fs.existsSync(path.join(localClient, 'index.html'))) {
+        projectPilotClientDist = localClient;
+      }
+    }
+
     const nodeExecPath = process.env.npm_node_execpath || process.execPath;
 
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PORT: String(port),
+      NODE_ENV: 'production',
+      ELECTRON_RUN_AS_NODE: '1',
+    };
+    if (projectPilotClientDist) {
+      childEnv.PROJECT_PILOT_CLIENT_DIST = projectPilotClientDist;
+    }
+
     const child = spawn(nodeExecPath, [serverPath], {
-      env: {
-        ...process.env,
-        PORT: String(port),
-        NODE_ENV: 'production',
-        ELECTRON_RUN_AS_NODE: '1',
-      },
+      env: childEnv,
       cwd: path.dirname(serverPath),
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/scripts/ci-compute-pr-desktop-version.mjs
+++ b/scripts/ci-compute-pr-desktop-version.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 /**
- * PR 桌面 CI：在合并基线 `package.json` 的 X.Y.Z 上做 **patch + 1**，再拼 `-pr.<PR号>`，
- * 得到安装包 / GitHub 预发布共用的版本号（不改仓库文件、不动 lock）。
+ * PR 桌面 CI：合并基线 `package.json` 的 X.Y.Z 做 **patch+1**，再拼 `-pr.<PR号>`；若存在环境变量
+ * **GITHUB_RUN_NUMBER**（Actions 默认注入），再拼 `.<run号>`，使「基线未 bump」时每次构建版本串仍不同。
+ *
+ * 基线 `version` 未变时，`0.1.6` 段会固定为 patch+1；要升正式号请在 `next` 上 `npm run release:desktop:bump` 或改 `package.json`。
  *
  * 用法：node scripts/ci-compute-pr-desktop-version.mjs <pr_number>
- *  stdout：单行版本字符串，例如 0.1.6-pr.42
+ *  stdout：例如 0.1.6-pr.42 或 0.1.6-pr.42.184523
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -27,5 +29,7 @@ if (!m) {
 const major = m[1];
 const minor = m[2];
 const patch = Number(m[3]) + 1;
-const v = `${major}.${minor}.${patch}-pr.${pr}`;
+const run = process.env.GITHUB_RUN_NUMBER?.trim() ?? '';
+const runSuffix = /^\d+$/.test(run) ? `.${run}` : '';
+const v = `${major}.${minor}.${patch}-pr.${pr}${runSuffix}`;
 process.stdout.write(v);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -171,9 +171,18 @@ app.route(api.googleAuth, lazyApiRoute(api.googleAuth, () => import('./routes/go
 app.route(api.root, lazyApiRoute(api.root, () => import('./routes/prompts')));
 
 // --- Static file serving (production) ---
-// Electron asar：`dist/server` 与 `dist/client` 须同处 unpacked，见 package.json `asarUnpack`。
-// 开发：`bun ./src/server/index.ts` 时 __dirname 为 `src/server`，须回退到仓库根下 `dist/client`。
+// Electron 子进程：由 `electron/server.ts` 注入 `PROJECT_PILOT_CLIENT_DIST`（resourcesPath 下 unpacked/asar），
+// 避免单文件 bundle 内 `__dirname` 与安装目录不一致导致找不到 `dist/client` → 浏览器 404。
+// 其它启动方式仍用候选路径探测。
 function resolveClientDistDir(): string | null {
+  const fromEnv = process.env.PROJECT_PILOT_CLIENT_DIST?.trim();
+  if (fromEnv) {
+    try {
+      if (fs.existsSync(path.join(fromEnv, 'index.html'))) return path.normalize(fromEnv);
+    } catch {
+      /* ignore */
+    }
+  }
   const candidates = [
     path.join(__dirname, '..', 'client'),
     path.resolve(__dirname, '..', '..', 'dist', 'client'),
@@ -188,6 +197,11 @@ function resolveClientDistDir(): string | null {
   return null;
 }
 const clientDistPath = resolveClientDistDir();
+if (!clientDistPath && process.env.NODE_ENV === 'production') {
+  console.error(
+    '[server] No client static root (no index.html). Set PROJECT_PILOT_CLIENT_DIST or run from dist/server with dist/client present.',
+  );
+}
 if (clientDistPath) {
   app.use('/*', serveStatic({ root: clientDistPath }));
   app.get('*', async (c) => {


### PR DESCRIPTION
## Electron (404)
- electron/server.ts: set PROJECT_PILOT_CLIENT_DIST from resourcesPath (unpacked client, asar fallback, or local dist/client) when index.html exists.
- src/server/index.ts: prefer that env in resolveClientDistDir(); log in production if still missing.

## PR desktop CI
- ci-compute-pr-desktop-version.mjs: append .GITHUB_RUN_NUMBER when set.
- pr-desktop-build.yml: pass GITHUB_RUN_NUMBER; bash regex tag cleanup for -pr.N.run.

Made with [Cursor](https://cursor.com)