### PR TITLE
fix(windows): NSIS wizard (path picker, finish, run app)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,12 @@
       "identity": null
     },
     "nsis": {
-      "oneClick": true,
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "allowElevation": true,
       "createDesktopShortcut": true,
-      "createStartMenuShortcut": true
+      "createStartMenuShortcut": true,
+      "runAfterFinish": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
Sets nsis.oneClick to false and enables allowToChangeInstallationDirectory, allowElevation, and runAfterFinish in package.json so Windows installers show a normal multi-step flow instead of a near-silent one-click install.

Made with [Cursor](https://cursor.com)