### PR TITLE
fix(agent-chat): treat empty provider/model as unset instead of invalid

### DIFF
--- a/src/components/agent-chat/agent-chat-panel.tsx
+++ b/src/components/agent-chat/agent-chat-panel.tsx
@@ -1381,7 +1381,7 @@ export function AgentChatPanel({
             message: messageToSend,
             sessionId: targetSessionId,
             projectKey: projectKey ?? undefined,
-            providerOverride: chatProvider,
+            providerOverride: chatProvider || undefined,
             modelOverride: chatModel || undefined,
             effortOverride: chatProvider === 'openai' ? chatEffort : undefined,
             fastModeOverride: chatProvider === 'openai' ? chatFastMode : undefined,
@@ -1390,7 +1390,7 @@ export function AgentChatPanel({
             config: (() => {
               const configWithModel = {
                 ...sessionConfig,
-                provider: chatProvider,
+                provider: chatProvider || undefined,
                 model: chatModel || undefined,
                 openaiReasoningEffort: chatProvider === 'openai' ? chatEffort : undefined,
                 openaiFastMode: chatProvider === 'openai' ? chatFastMode : undefined,

--- a/src/server/routes/agent-chat.ts
+++ b/src/server/routes/agent-chat.ts
@@ -195,11 +195,11 @@ app.post('/', async (c) => {
   }
 
   const normalizedProvider = (typeof providerOverride === 'string' ? providerOverride.trim() : '') as ProviderId;
-  if (providerOverride !== undefined && !isAllowedChatProvider(normalizedProvider)) {
+  if (normalizedProvider && !isAllowedChatProvider(normalizedProvider)) {
     return c.json({ error: 'Invalid providerOverride' }, 400);
   }
   const normalizedModel = typeof modelOverride === 'string' ? modelOverride.trim() : '';
-  if (modelOverride !== undefined && (!normalizedModel || normalizedModel.length > 200)) {
+  if (normalizedModel && normalizedModel.length > 200) {
     return c.json({ error: 'Invalid modelOverride (1-200 chars)' }, 400);
   }
   const normalizedEffort = normalizeOpenAIReasoningEffort(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 合并请求 · Pull Request

## 🌿 目标分支 / Base branch

- [x] 合并到 **`next`**

---

## 📝 说明 / Description

**中文**：

修复 Agent Chat "发送失败" + "切换会话点不动" 两个症状背后的同一病根。

### 病根因果链

```
aggregate-models 返回空列表（无 API 凭据配置）
  → useModelConfig 设 chatProvider = ""（空字符串）
    → 前端 POST body 中 providerOverride: ""
      → 后端验证：空字符串 ≠ undefined 且不在允许列表 → 400 "Invalid providerOverride"
        → eagerlySaveUserTurn 从未执行 → session 不写入磁盘
          → GET /sessions/:id → 404
            → 发送失败 + 切换会话无响应
```

### 修复（纵深防御）

1. **前端** (`agent-chat-panel.tsx`): `providerOverride: chatProvider || undefined`，空字符串转 `undefined`；同理 `config.provider`
2. **后端** (`agent-chat.ts`): 空字符串 providerOverride/modelOverride 视为"未指定"而非"非法"，只对非空非法值报 400

**English**: Fix "send failed" and "session switching unresponsive" caused by empty-string `providerOverride` being rejected as invalid by backend validation. When no API credentials are configured, `useModelConfig` sets `chatProvider` to `""`. The frontend passed this as `providerOverride`, which the backend treated as an invalid provider name (400 error), preventing session creation entirely.

---

## 🎯 改动类型 / Type of change

- [x] 🐛 缺陷修复

---

## ✅ 自检清单 / Checklist

- [x] 代码符合本项目风格约定
- [x] 已自行审阅改动
- [x] 无新增明显告警
- [x] 本地测试通过

---

## 🧪 测试说明 / Testing

- [x] `POST /api/agent-chat` 传 `providerOverride: ""` 返回 200（修复前返回 400）
- [x] `POST /api/agent-chat` 不传 `providerOverride` 返回 200
- [x] `POST /api/agent-chat` 传合法 `providerOverride: "anthropic"` 返回 200
- [x] `GET /api/agent-chat/sessions/:id` 修复后返回 200（修复前返回 404）
- [x] 浏览器端消息发送成功，session 正确创建并显示在侧边栏
- [x] 会话切换正常响应

---

## 📸 截图 / Screenshots

### 修复后：消息发送成功，session 正确创建
[Session created after fix](https://cursor.com/agents/bc-0c74a9d0-2447-4fee-9f2d-8de379c2e18a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_created_after_fix.webp)

### 修复后：控制台无 providerOverride 错误
[No providerOverride error](https://cursor.com/agents/bc-0c74a9d0-2447-4fee-9f2d-8de379c2e18a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_no_provider_error.webp)

### 端到端验证视频
[chat_fix_verified_send_and_switch.mp4](https://cursor.com/agents/bc-0c74a9d0-2447-4fee-9f2d-8de379c2e18a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_fix_verified_send_and_switch.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c74a9d0-2447-4fee-9f2d-8de379c2e18a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c74a9d0-2447-4fee-9f2d-8de379c2e18a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

