### PR TITLE
feat(public-site): refresh landing layout, styles, and entry assets

### DIFF
--- a/public-site/.gitignore
+++ b/public-site/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.local
+.superdesign-theme-m-ref.html

--- a/public-site/index.html
+++ b/public-site/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="ProjectPilot — Builder 的 AI 工作台：让 AI 对你的项目越来越懂，覆盖工程、产品、设计、商业、增长与运营。"
+      content="ProjectPilot — Builder 的 AI 工作台（严格黑白主题）：让 AI 越来越懂你的项目，本地优先、开源。"
     />
-    <title>ProjectPilot — Builder 的 AI 工作台</title>
+    <title>ProjectPilot — Builder AI Workbench</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/public-site/src/App.tsx
+++ b/public-site/src/App.tsx
@@ -1,280 +1,492 @@
+import { useEffect, useMemo, useState } from 'react';
+
 const REPO = 'https://github.com/Kaine665/Project-Pilot';
+const DOCS = `${REPO}/blob/main/docs/design/product-direction-and-dashboard.md`;
+const RELEASES_LATEST = `${REPO}/releases/latest`;
 
-const flywheel = [
-  { name: 'Memory', desc: '项目记忆与沉淀，让理解可累积。' },
-  { name: 'Loader', desc: '开聊前自动拼装上下文，少写背景说明。' },
-  { name: 'Runtime', desc: 'Agent 带着完整上下文执行。' },
-  { name: 'Distiller', desc: '聊完提炼决策与约定（路线图中）。' },
-  { name: 'Dashboard', desc: '一屏看见全局与下一步（路线图中）。' },
-] as const;
+type Locale = 'zh' | 'en';
 
-const dimensions = ['工程', '产品', '设计', '商业', '增长', '运营'] as const;
+const COPY: Record<
+  Locale,
+  {
+    langBtn: string;
+    heroTitle: string;
+    heroLead: string;
+    downloadMac: string;
+    downloadWin: string;
+    painTitle: string;
+    painBody: string;
+    painRows: [string, string];
+    benefits: { title: string; body: string }[];
+    positionTitle: string;
+    positionLead: string;
+    orbitLabel: string;
+    bandTitle: string;
+    slash1h: string;
+    slash1p: string;
+    slash2h: string;
+    slash2p: string;
+    quoteLabel: string;
+    quoteText: string;
+    faqLabel: string;
+    faq: { q: string; a: string }[];
+    finalTitle: string;
+    finalDocs: string;
+    footerMeta: string;
+  }
+> = {
+  zh: {
+    langBtn: '语言',
+    heroTitle: 'ProjectPilot',
+    heroLead:
+      '让 AI 对你的项目越来越懂，而不是每次聊起来都像第一次见面。Builder 专属的项目上下文与推进中心。',
+    downloadMac: '下载 macOS',
+    downloadWin: '下载 Windows',
+    painTitle: '上下文散落。',
+    painBody:
+      '对话一关，背景、决定、约定便散落在时间线中。你花费在解释「我们要做什么」上的时间，往往多过真正的构建。',
+    painRows: ['每次新会话都要重新交代项目背景', '产品、设计、工程上下文分散在多处'],
+    benefits: [
+      {
+        title: '更省事 —\n不重复讲故事',
+        body: 'Loader 与 Resource 自动将文档、代码与技能装载，告别每次开聊前的「背景说明」长篇大论。',
+      },
+      {
+        title: '更一致 —\n对齐决策与约定',
+        body: 'AI 知道你们定了什么、在做什么。让理解在多个会话间持续积累，而不是原地踏步。',
+      },
+      {
+        title: '更清楚 —\n全维度的推进感',
+        body: '不仅是写代码。工程、产品、设计、增长，一屏看清全局进展与下一步路线图。',
+      },
+    ],
+    positionTitle: '互补，而非二选一',
+    positionLead: 'AI 像帮手，ProjectPilot 则是帮帮手记住项目的「工作空间」。',
+    orbitLabel: '执行层 Execution AI',
+    bandTitle: 'Builder 的克制与边界',
+    slash1h: '不替代你的现有工具',
+    slash1p: '写代码仍在 IDE，管理文档仍在 Notion。PP 负责连接它们，而非吞没它们。',
+    slash2h: '不是又一个通用聊天框',
+    slash2p: '我们不做机器人广场。我们专注「推进你手头那件事」的上下文。',
+    quoteLabel: '核心价值观',
+    quoteText: '“个人与项目的上下文，值得留在自己掌控的环境里。我们选择开源与本地优先。”',
+    faqLabel: '常见问题 FAQ',
+    faq: [
+      {
+        q: '和 Cursor / Claude Code 有什么区别？',
+        a: '互补关系。它们侧重执行，PP 侧重记忆与跨会话的上下文装载。你可以用 PP 准备好上下文，然后在 IDE 中执行。',
+      },
+      {
+        q: '数据存在哪里？',
+        a: '默认以本地磁盘为主。适合希望上下文留在自己环境下的独立 Builder。',
+      },
+      {
+        q: '是否支持团队协作？',
+        a: '目前聚焦于单人或小团队的高密度推进。通过 Git 同步配置是推荐的协作方式。',
+      },
+      {
+        q: '开源协议？',
+        a: '在 GitHub 公开维护。欢迎审计、分叉或提交 PR，共同完善 Builder 工作流。',
+      },
+    ],
+    finalTitle: '准备好开始沉淀了吗？',
+    finalDocs: '阅读设计文档',
+    footerMeta: 'Open source workbench · Built for builders',
+  },
+  en: {
+    langBtn: 'Language',
+    heroTitle: 'ProjectPilot',
+    heroLead:
+      'Help AI understand your project over time—not from scratch every chat. A project context and progress hub for builders.',
+    downloadMac: 'Download for macOS',
+    downloadWin: 'Download for Windows',
+    painTitle: 'Context Scattering.',
+    painBody:
+      'When the chat ends, background, decisions, and agreements drift across timelines. You often spend more time re-explaining than building.',
+    painRows: [
+      'Every new session needs the project context explained again',
+      'Product, design, and engineering context live in different tools',
+    ],
+    benefits: [
+      {
+        title: 'Less repetition —\nstop retelling the story',
+        body: 'Loader and Resource pull docs, code, and skills in automatically—fewer long “here is our background” preambles.',
+      },
+      {
+        title: 'More consistency —\nalign decisions',
+        body: 'The model knows what you decided and what is in flight—understanding compounds across sessions.',
+      },
+      {
+        title: 'Clearer progress —\nacross dimensions',
+        body: 'Not only code—engineering, product, design, and growth in one place to see what is next.',
+      },
+    ],
+    positionTitle: 'Complementary, not either-or',
+    positionLead: 'AI tools execute; ProjectPilot is the workspace that helps them remember the project.',
+    orbitLabel: 'Execution layer · Execution AI',
+    bandTitle: 'Restraint and boundaries',
+    slash1h: 'We do not replace your existing tools',
+    slash1p: 'You still code in your IDE and write docs where you like—PP connects them instead of swallowing them.',
+    slash2h: 'Not another generic chat box',
+    slash2p: 'No bot marketplace—focus on context for the project you are actually pushing forward.',
+    quoteLabel: 'Core values',
+    quoteText:
+      '“Project context deserves to live in an environment you control. We choose open source and local-first.”',
+    faqLabel: 'FAQ',
+    faq: [
+      {
+        q: 'How is this different from Cursor / Claude Code?',
+        a: 'They focus on execution; PP focuses on memory and cross-session context loading. Prepare context in PP, then execute in your IDE.',
+      },
+      {
+        q: 'Where does data live?',
+        a: 'Primarily on local disk—suited to builders who want context to stay in their own environment.',
+      },
+      {
+        q: 'Team collaboration?',
+        a: 'Optimized for solo builders and small teams today; syncing configuration via Git is the recommended path.',
+      },
+      {
+        q: 'License?',
+        a: 'Maintained in public on GitHub—audits, forks, and PRs welcome.',
+      },
+    ],
+    finalTitle: 'Ready to start compounding?',
+    finalDocs: 'Read the product design doc',
+    footerMeta: 'Open source workbench · Built for builders',
+  },
+};
 
-const reality = [
-  '每个新会话都要重新交代项目背景与约束。',
-  '工程、产品、运营混在一起，却分散在多个工具里。',
-  '买越多 SaaS，越要在「学工具」和「切窗口」上花时间。',
-] as const;
+const BENEFIT_ICONS = [IconBattery, IconBranch, IconLayout] as const;
 
-const ppAnswers = [
-  'Loader 与 Resource：把项目、文档、技能自动带进对话前上下文。',
-  '六维结构 + 任务：用固定大维度承接真实 Builder 节奏，而不是只盯代码。',
-  '本地优先的数据与编排：上下文留在你的机器与习惯工作流里。',
-] as const;
+function IconGithub({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
 
-const paradigm = [
-  {
-    label: '聊天框思维',
-    meta: 'Task-centered',
-    points: ['一轮一轮从零解释', '能力边界由产品预设', '上下文靠你手动投喂'],
-  },
-  {
-    label: '工作台思维',
-    meta: 'Project-centered',
-    points: ['项目理解跨会话延续', 'Agent + 任务 + 触发器一起跑', '资源注册表自动装载'],
-  },
-] as const;
+function IconApple({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.47 2.35-1.46 3.08C14.34 5.83 13.17 5.3 13 3.5" />
+    </svg>
+  );
+}
 
-const levels = [
-  {
-    id: '00',
-    title: '从 Agent 对话开始',
-    subtitle: '先从一个能访问本地项目空间的聊天界面用起来。',
-    bullets: ['多模型运行时（如 Claude / Codex）', 'Guest、Butler 等内置与自定义 Agent'],
-  },
-  {
-    id: '01',
-    title: '上下文自己长出来',
-    subtitle: 'ResourceRegistry 在会话前拼装项目、文档与技能。',
-    bullets: ['提示词分段与项目级 Prompt', '文档与知识形态统一收纳'],
-  },
-  {
-    id: '02',
-    title: '把推进接进同一处',
-    subtitle: '待办、定时与事件触发，让「聊完即忘」变成可跟进的状态。',
-    bullets: ['任务与调度（成熟度见仓库路线图）', '桌面端 Electron 一体化开发体验'],
-  },
-  {
-    id: '03',
-    title: '记忆飞轮转起来',
-    subtitle: 'Distiller 与 Dashboard 在路线图中，目标是一边做一边沉淀全局视图。',
-    bullets: ['五模块：Memory → Loader → Runtime → Distiller → Dashboard', '为「聊完即资产」铺路'],
-  },
-] as const;
+function IconWindows({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M3 5.5 11 4.2v7.3H3V5.5zm8-.3 10-1.5v9H11V5.2zM3 13.3h8v7.3l-8-1.2v-6.1zm9 0h10v9l-10-1.4v-7.6z" />
+    </svg>
+  );
+}
 
-const stackPills = ['Claude Agent SDK', 'OpenAI Codex', 'MCP', 'Hono', 'Vite + React', 'Electron'] as const;
+function IconLayers({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
 
-const faq = [
-  {
-    q: 'ProjectPilot 是通用 Agent 平台吗？',
-    a: '不是。它面向「推进你自己的项目」：上下文、文档、任务与多 Agent 编排，而不是做一个与项目无关的聊天机器人市场。',
-  },
-  {
-    q: '和 Cursor / Claude Code 是什么关系？',
-    a: '互补。PP 侧重项目记忆、装载与工作台编排；具体写代码、改文件仍可在你喜欢的 IDE 与 CLI 里完成，由你接入的模型与工具执行。',
-  },
-  {
-    q: '数据存在哪里？',
-    a: '默认以本地磁盘为主（详见仓库 README 与 docs/data-storage）。适合希望上下文留在自己环境下的 Builder。',
-  },
-  {
-    q: '开源协议与参与方式？',
-    a: '源码在 GitHub 公开维护。欢迎提 Issue、PR 以及在 README 指引下本地运行体验。',
-  },
-] as const;
+function IconAlert({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 8v4M12 16h.01" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IconBox({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M3.27 6.96L12 12.01l8.73-5.05M12 22.08V12" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconBattery({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <rect x="1" y="6" width="18" height="12" rx="2" />
+      <path d="M23 13v-2" />
+    </svg>
+  );
+}
+
+function IconBranch({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M6 3v12M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM18 9a9 9 0 0 1-9 9" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconLayout({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <rect x="3" y="3" width="7" height="9" rx="1" />
+      <rect x="14" y="3" width="7" height="5" rx="1" />
+      <rect x="14" y="12" width="7" height="9" rx="1" />
+      <rect x="3" y="16" width="7" height="5" rx="1" />
+    </svg>
+  );
+}
+
+function IconSlash({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M4.93 4.93l14.14 14.14" />
+    </svg>
+  );
+}
+
+function IconTarget({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="6" />
+      <circle cx="12" cy="12" r="2" />
+    </svg>
+  );
+}
 
 export default function App() {
+  const [locale, setLocale] = useState<Locale>('zh');
+  const t = useMemo(() => COPY[locale], [locale]);
+
+  useEffect(() => {
+    document.documentElement.lang = locale === 'zh' ? 'zh-CN' : 'en';
+  }, [locale]);
+
   return (
-    <div className="pps">
-      <div className="pps-bg" aria-hidden />
-      <header className="pps-nav">
-        <a className="pps-brand" href="#top">
-          <span className="pps-logo" aria-hidden />
-          <span>ProjectPilot</span>
-        </a>
-        <nav className="pps-nav-links" aria-label="页面内导航">
-          <a href="#compare">痛点</a>
-          <a href="#paradigm">范式</a>
-          <a href="#levels">如何开始</a>
-          <a href="#flywheel">飞轮</a>
-          <a href="#faq">FAQ</a>
-        </nav>
-        <a className="pps-btn pps-btn-ghost" href={REPO} target="_blank" rel="noreferrer">
-          GitHub
-        </a>
+    <div className="ppm">
+      <div className="ppm-texture" aria-hidden />
+
+      <header className="ppm-nav">
+        <div className="ppm-layout-inner ppm-nav-inner">
+          <a className="ppm-brand" href="#top">
+            <span className="ppm-logo" aria-hidden>
+              <IconLayers className="ppm-logo-svg" />
+            </span>
+            <span className="ppm-brand-text">ProjectPilot</span>
+          </a>
+          <div className="ppm-nav-end">
+            <button
+              type="button"
+              className="ppm-nav-lang-btn"
+              aria-label={locale === 'zh' ? '切换为英文界面' : 'Switch to Chinese interface'}
+              onClick={() => setLocale((prev) => (prev === 'zh' ? 'en' : 'zh'))}
+            >
+              {t.langBtn}
+            </button>
+            <a className="ppm-nav-gh" href={REPO} target="_blank" rel="noreferrer">
+              <IconGithub className="ppm-nav-gh-icon" />
+              GitHub
+            </a>
+          </div>
+        </div>
       </header>
 
       <main id="top">
-        <section className="pps-hero">
-          <p className="pps-tagline">本地优先的 Builder 工作台 · 开源</p>
-          <h1 className="pps-title">
-            <span className="pps-title-line">全维度的</span>{' '}
-            <span className="pps-gradient">项目 AI 工作台</span>
-          </h1>
-          <p className="pps-lead">
-            让 AI 对你的项目越来越懂，而不是每次从零开始。把工程、产品、设计、商业、增长与运营的上下文，接进同一套记忆与执行飞轮。
-          </p>
-          <div className="pps-hero-actions">
-            <a className="pps-btn pps-btn-primary" href={REPO} target="_blank" rel="noreferrer">
-              在 GitHub 上查看
-            </a>
-            <a className="pps-btn pps-btn-secondary" href={`${REPO}#readme`} target="_blank" rel="noreferrer">
-              阅读 README
-            </a>
-          </div>
-          <p className="pps-trust">适合独立 Builder、小团队创始人与「一人公司」式节奏的多线程推进。</p>
-        </section>
-
-        <section id="compare" className="pps-section pps-section--alt">
-          <h2 className="pps-h2">为什么 Builder 需要的不是又一个「纯聊天」</h2>
-          <p className="pps-sub">你的现实里角色很多，工具很碎；PP 想接住的是「项目」本身，而不是单条对话。</p>
-          <div className="pps-compare">
-            <div className="pps-compare-col pps-compare-col--muted">
-              <h3 className="pps-compare-heading">常见痛点</h3>
-              <ul>
-                {reality.map((t) => (
-                  <li key={t}>{t}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="pps-compare-col pps-compare-col--accent">
-              <h3 className="pps-compare-heading">ProjectPilot</h3>
-              <ul>
-                {ppAnswers.map((t) => (
-                  <li key={t}>{t}</li>
-                ))}
-              </ul>
+        <section className="ppm-hero">
+          <div className="ppm-layout-inner">
+            <h1 className="ppm-hero-title">{t.heroTitle}</h1>
+            <p className="ppm-hero-lead">{t.heroLead}</p>
+            <div className="ppm-hero-actions">
+              <a
+                className="ppm-dl-btn"
+                href={RELEASES_LATEST}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`${t.downloadMac} — GitHub Releases`}
+              >
+                <IconApple className="ppm-dl-icon" />
+                {t.downloadMac}
+              </a>
+              <a
+                className="ppm-dl-btn"
+                href={RELEASES_LATEST}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`${t.downloadWin} — GitHub Releases`}
+              >
+                <IconWindows className="ppm-dl-icon" />
+                {t.downloadWin}
+              </a>
             </div>
           </div>
         </section>
 
-        <section id="paradigm" className="pps-section">
-          <h2 className="pps-h2">从「任务工具」到「项目伙伴」</h2>
-          <p className="pps-sub mono">参考「以任务为中心」与「以用户与项目为中心」的对照思路，重新理解工作台该长什么样。</p>
-          <div className="pps-paradigm">
-            {paradigm.map((col) => (
-              <div key={col.label} className="pps-paradigm-card">
-                <p className="pps-paradigm-meta mono">{col.meta}</p>
-                <h3>{col.label}</h3>
-                <ul>
-                  {col.points.map((p) => (
-                    <li key={p}>{p}</li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section id="levels" className="pps-section pps-section--alt">
-          <h2 className="pps-h2">如何真正开始用起来</h2>
-          <p className="pps-sub">像搭积木一样从简单界面起步，再按需要展开模块——与「先聊天、再长工作空间」的节奏一致。</p>
-          <div className="pps-levels">
-            {levels.map((L) => (
-              <article key={L.id} className="pps-level">
-                <div className="pps-level-head">
-                  <span className="pps-level-id mono">{L.id}</span>
-                  <div>
-                    <h3>{L.title}</h3>
-                    <p className="pps-level-sub">{L.subtitle}</p>
+        <section id="pain" className="ppm-section">
+          <div className="ppm-layout-inner">
+            <div className="ppm-pain-grid">
+            <div>
+              <h2 className="ppm-h2">{t.painTitle}</h2>
+              <p className="ppm-muted-lg">{t.painBody}</p>
+              <ul className="ppm-pain-list">
+                {t.painRows.map((row) => (
+                  <li key={row} className="ppm-pain-row">
+                    <IconAlert className="ppm-pain-icon" />
+                    <span>{row}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="ppm-visual">
+              <div className="ppm-visual-inner">
+                <div className="ppm-visual-chaos ppm-visual-chaos-a" />
+                <div className="ppm-visual-chaos ppm-visual-chaos-b" />
+                <div className="ppm-visual-core">
+                  <span className="ppm-visual-core-icon">
+                    <IconBox className="ppm-visual-box" />
+                  </span>
+                  <span className="ppm-visual-core-title">Project Memory</span>
+                  <div className="ppm-visual-bars">
+                    <span className="ppm-visual-bar">
+                      <span className="ppm-visual-bar-fill" style={{ width: '66%' }} />
+                    </span>
+                    <span className="ppm-visual-bar">
+                      <span className="ppm-visual-bar-fill" style={{ width: '50%' }} />
+                    </span>
                   </div>
                 </div>
-                <ul>
-                  {L.bullets.map((b) => (
-                    <li key={b}>{b}</li>
-                  ))}
-                </ul>
-              </article>
-            ))}
+                <svg className="ppm-visual-lines" viewBox="0 0 100 100" aria-hidden>
+                  <path d="M20,20 L50,50" fill="none" stroke="currentColor" strokeWidth="0.35" />
+                  <path d="M80,20 L50,50" fill="none" stroke="currentColor" strokeWidth="0.35" />
+                  <path d="M20,80 L50,50" fill="none" stroke="currentColor" strokeWidth="0.35" />
+                  <path d="M80,80 L50,50" fill="none" stroke="currentColor" strokeWidth="0.35" />
+                </svg>
+              </div>
+            </div>
+            </div>
           </div>
         </section>
 
-        <section className="pps-section">
-          <h2 className="pps-h2">与你已有的 AI 能力接在一起</h2>
-          <p className="pps-sub">不锁死单一厂商；由你配置密钥与运行时（具体以仓库实现为准）。</p>
-          <div className="pps-pills" role="list">
-            {stackPills.map((name) => (
-              <span key={name} className="pps-pill mono" role="listitem">
-                {name}
-              </span>
-            ))}
+        <section id="benefits" className="ppm-section">
+          <div className="ppm-layout-inner">
+            <div className="ppm-benefits-card">
+            <div className="ppm-benefits-grid">
+              {t.benefits.map((b, i) => {
+                const Icon = BENEFIT_ICONS[i];
+                return (
+                  <div key={b.title} className="ppm-benefit">
+                    <span className="ppm-benefit-icon-wrap">
+                      <Icon className="ppm-benefit-icon" />
+                    </span>
+                    <h3 className="ppm-benefit-title">{b.title}</h3>
+                    <p className="ppm-benefit-body">{b.body}</p>
+                  </div>
+                );
+              })}
+            </div>
+            </div>
           </div>
         </section>
 
-        <section id="flywheel" className="pps-section pps-section--alt">
-          <h2 className="pps-h2">五模块飞轮</h2>
-          <p className="pps-sub mono">Memory → Loader → Runtime → Distiller → Dashboard</p>
-          <ol className="pps-flywheel">
-            {flywheel.map((m, i) => (
-              <li key={m.name} className="pps-fly-item">
-                <span className="pps-fly-index mono">{String(i + 1).padStart(2, '0')}</span>
-                <div>
-                  <strong>{m.name}</strong>
-                  <p>{m.desc}</p>
+        <section id="position" className="ppm-section ppm-center">
+          <div className="ppm-layout-inner">
+            <h2 className="ppm-h2">{t.positionTitle}</h2>
+            <p className="ppm-muted-lg">{t.positionLead}</p>
+            <div className="ppm-orbit-wrap">
+              <div className="ppm-orbit-label mono">{t.orbitLabel}</div>
+              <div className="ppm-orbit">
+                <span className="ppm-orbit-tag ppm-orbit-tag-a">Claude / IDE</span>
+                <span className="ppm-orbit-tag ppm-orbit-tag-b">CLI Tools</span>
+                <span className="ppm-orbit-tag ppm-orbit-tag-c">Agents</span>
+                <div className="ppm-orbit-core">
+                  <IconTarget className="ppm-orbit-core-icon" />
+                  <h4 className="ppm-orbit-core-title">Project Memory</h4>
+                  <p className="ppm-orbit-core-meta mono">Loader · Distiller · Dashboard</p>
                 </div>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        <section id="dimensions" className="pps-section">
-          <h2 className="pps-h2">六维项目结构</h2>
-          <p className="pps-sub">大维度固定、小板块可演进；任务与知识可跨维度关联。</p>
-          <ul className="pps-dim-grid">
-            {dimensions.map((d) => (
-              <li key={d} className="pps-dim">
-                {d}
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <section className="pps-quote pps-section--alt">
-          <blockquote>
-            <p>
-              个人与项目的上下文值得留在自己掌控的环境里。ProjectPilot 选择开源，方便你审计、分叉与把它接进自己的工作流。
-            </p>
-          </blockquote>
-          <a className="pps-btn pps-btn-outline pps-quote-btn" href={REPO} target="_blank" rel="noreferrer">
-            Star on GitHub
-          </a>
-        </section>
-
-        <section id="faq" className="pps-section">
-          <h2 className="pps-h2">常见问题</h2>
-          <div className="pps-faq">
-            {faq.map((item) => (
-              <details key={item.q} className="pps-faq-item">
-                <summary>{item.q}</summary>
-                <p>{item.a}</p>
-              </details>
-            ))}
+              </div>
+            </div>
           </div>
         </section>
 
-        <section className="pps-cta-band" aria-labelledby="cta-title">
-          <h2 id="cta-title" className="pps-cta-title">
-            准备把项目上下文接进同一工作台了吗？
-          </h2>
-          <p className="pps-cta-lead">克隆仓库、按 README 启动 Vite + Hono 或 Electron 开发模式，即可本地体验。</p>
-          <div className="pps-hero-actions">
-            <a className="pps-btn pps-btn-primary" href={REPO} target="_blank" rel="noreferrer">
-              打开 GitHub 仓库
-            </a>
-            <a className="pps-btn pps-btn-secondary" href={`${REPO}/blob/main/docs/design/product-direction-and-dashboard.md`} target="_blank" rel="noreferrer">
-              阅读产品设计文档
-            </a>
+        <section className="ppm-band">
+          <div className="ppm-layout-inner">
+            <div className="ppm-band-grid">
+              <div>
+                <h2 className="ppm-h2">{t.bandTitle}</h2>
+                <ul className="ppm-slash-list">
+                  <li>
+                    <IconSlash className="ppm-slash-icon" />
+                    <div>
+                      <h4 className="ppm-slash-h">{t.slash1h}</h4>
+                      <p className="ppm-slash-p">{t.slash1p}</p>
+                    </div>
+                  </li>
+                  <li>
+                    <IconSlash className="ppm-slash-icon" />
+                    <div>
+                      <h4 className="ppm-slash-h">{t.slash2h}</h4>
+                      <p className="ppm-slash-p">{t.slash2p}</p>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <blockquote className="ppm-quote-card">
+                <p className="mono ppm-quote-label">{t.quoteLabel}</p>
+                <p className="ppm-quote-text">{t.quoteText}</p>
+                <div className="ppm-quote-foot">
+                  <span className="ppm-quote-avatar" aria-hidden />
+                  <span className="ppm-quote-team">ProjectPilot</span>
+                </div>
+              </blockquote>
+            </div>
+          </div>
+        </section>
+
+        <section id="faq" className="ppm-section">
+          <div className="ppm-layout-inner">
+            <h2 className="ppm-faq-label mono">{t.faqLabel}</h2>
+            <div className="ppm-faq-grid">
+              {t.faq.map((item) => (
+                <div key={item.q}>
+                  <h4 className="ppm-faq-q">{item.q}</h4>
+                  <p className="ppm-faq-a">{item.a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="ppm-final-cta" aria-labelledby="final-cta">
+          <div className="ppm-layout-inner">
+            <h2 id="final-cta" className="ppm-final-title">
+              {t.finalTitle}
+            </h2>
+            <div className="ppm-final-actions">
+              <a className="ppm-btn ppm-btn-on-dark" href={REPO} target="_blank" rel="noreferrer">
+                GitHub Repository
+              </a>
+              <a className="ppm-link-on-dark" href={DOCS} target="_blank" rel="noreferrer">
+                {t.finalDocs}
+              </a>
+            </div>
           </div>
         </section>
       </main>
 
-      <footer className="pps-footer">
-        <p>
-          <span className="mono">ProjectPilot</span> — 开源项目，欢迎 Issue 与 PR。
-        </p>
-        <a href={REPO} target="_blank" rel="noreferrer">
-          {REPO}
-        </a>
+      <footer className="ppm-footer">
+        <div className="ppm-layout-inner ppm-footer-inner">
+          <div className="ppm-footer-brand">
+            <span className="ppm-footer-mark mono" aria-hidden>
+              PP
+            </span>
+            <span className="ppm-footer-name">ProjectPilot</span>
+          </div>
+          <p className="ppm-footer-meta mono">{t.footerMeta}</p>
+          <a className="ppm-footer-gh" href={REPO} target="_blank" rel="noreferrer" aria-label="GitHub">
+            <IconGithub className="ppm-footer-gh-icon" />
+          </a>
+        </div>
       </footer>
     </div>
   );

--- a/public-site/src/index.css
+++ b/public-site/src/index.css
@@ -1,24 +1,20 @@
+/* Theme M — Strict Monochrome (Superdesign draft 4f15e77c…, light editorial) */
+
 :root {
-  --bg-deep: #040406;
-  --bg-surface: #0a0b10;
-  --bg-elevated: #10121a;
-  --bg-card: rgba(20, 22, 34, 0.75);
-  --border: rgba(140, 150, 190, 0.14);
-  --border-strong: rgba(167, 180, 220, 0.22);
-  --text: #f0f2f8;
-  --text-muted: #949ab3;
-  --accent-from: #a78bfa;
-  --accent-to: #38e8ff;
-  --accent-mid: #7dd3fc;
-  --glow: rgba(139, 92, 246, 0.28);
-  --glow-cyan: rgba(56, 232, 255, 0.12);
-  --compare-accent-bg: rgba(56, 232, 255, 0.06);
-  --compare-accent-border: rgba(56, 232, 255, 0.2);
+  --ppm-bg: #ffffff;
+  --ppm-text: #000000;
+  --ppm-muted: #525252;
+  --ppm-muted-lg: #71717a;
+  --ppm-border: #e4e4e7;
+  --ppm-border-soft: #e6e4de;
+  --ppm-surface: #fafafa;
+  --ppm-surface-2: #f4f4f5;
+  --ppm-ink: #18181b;
   font-family: 'DM Sans', system-ui, sans-serif;
   line-height: 1.55;
   font-weight: 400;
-  color: var(--text);
-  background-color: var(--bg-deep);
+  color: var(--ppm-text);
+  background-color: var(--ppm-bg);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -53,612 +49,898 @@ a:hover {
   text-underline-offset: 3px;
 }
 
-.pps {
+.ppm {
   position: relative;
   min-height: 100vh;
-  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
-.pps-bg {
+.ppm-texture {
   pointer-events: none;
   position: fixed;
   inset: 0;
-  background:
-    radial-gradient(ellipse 90% 55% at 50% -25%, var(--glow), transparent 55%),
-    radial-gradient(ellipse 45% 35% at 95% 15%, var(--glow-cyan), transparent),
-    radial-gradient(ellipse 40% 30% at 5% 30%, rgba(167, 139, 250, 0.14), transparent),
-    var(--bg-deep);
   z-index: 0;
+  opacity: 0.02;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
-.pps-nav,
-.pps-hero,
-.pps-section,
-.pps-quote,
-.pps-cta-band,
-.pps-footer {
+.ppm-nav,
+.ppm-hero,
+.ppm-section,
+.ppm-band,
+.ppm-final-cta,
+.ppm-footer,
+main#top {
   position: relative;
   z-index: 1;
 }
 
-.pps-nav {
+main#top {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* 每个主版面至少一屏高；内层垂直居中（内容超高时 safe 对齐避免裁切） */
+main#top > section {
+  box-sizing: border-box;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+main#top > section > .ppm-layout-inner {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+}
+
+/* 短版心：在「一屏」内垂直居中 */
+.ppm-hero > .ppm-layout-inner,
+.ppm-final-cta > .ppm-layout-inner {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* 全宽背景条 + 1200px 视觉内容区（与顶栏同一套宽度） */
+.ppm-layout-inner {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1200px;
+  margin-inline: auto;
+  padding-inline: 1.5rem;
+}
+
+.ppm-nav {
   position: sticky;
   top: 0;
+  z-index: 10;
+  width: 100%;
+  border-bottom: 1px solid var(--ppm-border-soft);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+}
+
+.ppm-nav-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(14px);
-  background: rgba(4, 4, 6, 0.78);
-  z-index: 10;
+  padding-block: 1rem;
 }
 
-.pps-brand {
+.ppm-brand {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-.pps-brand:hover {
-  text-decoration: none;
-  opacity: 0.92;
-}
-
-.pps-logo {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.5rem;
-  background: linear-gradient(135deg, var(--accent-from), var(--accent-to));
-  box-shadow: 0 0 28px var(--glow);
-}
-
-.pps-nav-links {
-  display: none;
-  gap: 1.35rem;
-  color: var(--text-muted);
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.pps-nav-links a:hover {
-  color: var(--text);
-  text-decoration: none;
-}
-
-@media (min-width: 880px) {
-  .pps-nav-links {
-    display: flex;
-  }
-}
-
-.pps-hero {
-  max-width: 880px;
-  margin: 0 auto;
-  padding: 3.25rem 1.5rem 3.5rem;
-  text-align: center;
-}
-
-.pps-tagline {
-  display: inline-block;
-  margin: 0 0 1.25rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: var(--accent-mid);
-  border: 1px solid rgba(125, 211, 252, 0.35);
-  background: rgba(56, 232, 255, 0.08);
-  letter-spacing: 0.02em;
-}
-
-.pps-title {
-  font-size: clamp(2.35rem, 6.2vw, 3.65rem);
+  gap: 0.5rem;
   font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.08;
-  margin: 0 0 1.35rem;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  font-size: 1.05rem;
 }
 
-.pps-title-line {
-  display: inline;
-  color: var(--text);
+.ppm-brand:hover {
+  text-decoration: none;
+  opacity: 0.85;
 }
 
-@media (max-width: 520px) {
-  .pps-title-line {
-    display: block;
-    margin-bottom: 0.15rem;
-  }
-}
-
-.pps-gradient {
-  background: linear-gradient(100deg, var(--accent-from), var(--accent-to));
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.pps-lead {
-  margin: 0 auto 2rem;
-  max-width: 36rem;
-  font-size: 1.0625rem;
-  color: var(--text-muted);
-  line-height: 1.65;
-}
-
-.pps-hero-actions {
+.ppm-logo {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.25rem;
+  background: var(--ppm-text);
+  color: #fff;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  align-items: center;
   justify-content: center;
 }
 
-.pps-trust {
-  margin: 2rem 0 0;
-  font-size: 0.8125rem;
-  color: var(--text-muted);
-  max-width: 28rem;
-  margin-left: auto;
-  margin-right: auto;
-  line-height: 1.5;
+.ppm-logo-svg {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
-.pps-btn {
+.ppm-nav-end {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-shrink: 0;
+}
+
+.ppm-nav-lang-btn {
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: 0.35rem;
+  background: transparent;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ppm-muted-lg);
+  cursor: pointer;
+}
+
+.ppm-nav-lang-btn:hover {
+  color: var(--ppm-text);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.ppm-nav-gh {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem 0.35rem 0.85rem;
+  border: 1px solid var(--ppm-ink);
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ppm-nav-gh:hover {
+  background: var(--ppm-ink);
+  color: #fff;
+  text-decoration: none;
+}
+
+.ppm-nav-gh-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.ppm-hero {
+  width: 100%;
+  margin: 0;
+  padding: clamp(2rem, 6vh, 4rem) 0;
+  text-align: center;
+  background: var(--ppm-surface);
+  border-bottom: 1px solid var(--ppm-border);
+}
+
+.ppm-hero-title {
+  margin: 0 0 2rem;
+  font-size: clamp(2.75rem, 10vw, 5.5rem);
+  font-weight: 600;
+  letter-spacing: -0.045em;
+  line-height: 0.92;
+}
+
+.ppm-hero-lead {
+  max-width: 36rem;
+  margin: 0 auto 3rem;
+  font-size: 1.25rem;
+  color: var(--ppm-muted-lg);
+  line-height: 1.6;
+  font-weight: 400;
+}
+
+.ppm-hero-actions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+.ppm-dl-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.7rem 1.35rem;
+  gap: 0.5rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 1.15rem;
+  border: 1px solid var(--ppm-border);
   border-radius: 0.65rem;
-  font-size: 0.9rem;
+  background: #fff;
+  font-size: 0.875rem;
   font-weight: 600;
-  border: 1px solid transparent;
-  cursor: pointer;
+  color: var(--ppm-text);
   transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease,
+    background 0.15s ease,
     border-color 0.15s ease,
-    background 0.15s ease;
+    transform 0.15s ease;
 }
 
-.pps-btn:hover {
+.ppm-dl-btn:hover {
+  background: var(--ppm-surface-2);
+  border-color: #d4d4d8;
   text-decoration: none;
   transform: translateY(-1px);
 }
 
-.pps-btn-primary {
-  background: linear-gradient(135deg, #7c3aed, #0e7490);
-  color: #fff;
-  box-shadow: 0 6px 28px rgba(124, 58, 237, 0.38);
-}
-
-.pps-btn-primary:hover {
-  box-shadow: 0 8px 32px rgba(124, 58, 237, 0.48);
-}
-
-.pps-btn-secondary {
-  background: var(--text);
-  color: #0f1117;
-  border-color: transparent;
-}
-
-.pps-btn-secondary:hover {
-  box-shadow: 0 6px 24px rgba(240, 242, 248, 0.15);
-}
-
-.pps-btn-outline {
-  border-color: var(--border-strong);
-  background: var(--bg-card);
-  color: var(--text);
-}
-
-.pps-btn-outline:hover {
-  border-color: rgba(167, 180, 220, 0.35);
-  background: rgba(28, 30, 44, 0.9);
-}
-
-.pps-btn-ghost {
-  border-color: var(--border);
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  font-weight: 500;
-  padding: 0.5rem 1rem;
-}
-
-.pps-btn-ghost:hover {
-  color: var(--text);
-  border-color: rgba(140, 150, 190, 0.28);
-}
-
-.pps-section {
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 3.25rem 1.5rem;
-}
-
-.pps-section--alt {
-  background: linear-gradient(180deg, rgba(10, 11, 16, 0.92), rgba(6, 7, 11, 0.5));
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.pps-h2 {
-  font-size: clamp(1.35rem, 3vw, 1.75rem);
-  font-weight: 600;
-  letter-spacing: -0.025em;
-  margin: 0 0 0.6rem;
-  line-height: 1.25;
-}
-
-.pps-sub {
-  margin: 0 0 2rem;
-  color: var(--text-muted);
-  max-width: 46rem;
-  font-size: 0.9375rem;
-  line-height: 1.6;
-}
-
-.pps-compare {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 720px) {
-  .pps-compare {
-    grid-template-columns: 1fr 1fr;
-    gap: 1.25rem;
-  }
-}
-
-.pps-compare-col {
-  border-radius: 1rem;
-  padding: 1.35rem 1.4rem;
-  border: 1px solid var(--border);
-}
-
-.pps-compare-col--muted {
-  background: rgba(12, 14, 20, 0.55);
-}
-
-.pps-compare-col--accent {
-  background: var(--compare-accent-bg);
-  border-color: var(--compare-accent-border);
-  box-shadow: 0 0 0 1px rgba(56, 232, 255, 0.06);
-}
-
-.pps-compare-heading {
-  margin: 0 0 1rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-.pps-compare-col ul {
-  margin: 0;
-  padding: 0 0 0 1.1rem;
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  line-height: 1.65;
-}
-
-.pps-compare-col--accent ul {
-  color: #c6cad8;
-}
-
-.pps-compare-col li + li {
-  margin-top: 0.65rem;
-}
-
-.pps-paradigm {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 720px) {
-  .pps-paradigm {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.pps-paradigm-card {
-  border-radius: 1rem;
-  padding: 1.5rem 1.35rem;
-  border: 1px solid var(--border);
-  background: var(--bg-card);
-  backdrop-filter: blur(12px);
-}
-
-.pps-paradigm-meta {
-  margin: 0 0 0.35rem;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-muted);
-}
-
-.pps-paradigm-card h3 {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
-  font-weight: 600;
-}
-
-.pps-paradigm-card ul {
-  margin: 0;
-  padding: 0 0 0 1.1rem;
-  font-size: 0.88rem;
-  color: var(--text-muted);
-  line-height: 1.6;
-}
-
-.pps-paradigm-card li + li {
-  margin-top: 0.5rem;
-}
-
-.pps-levels {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.pps-level {
-  border-radius: 1rem;
-  border: 1px solid var(--border);
-  background: rgba(14, 16, 24, 0.65);
-  padding: 1.35rem 1.4rem 1.25rem;
-}
-
-.pps-level-head {
-  display: flex;
-  gap: 1.1rem;
-  align-items: flex-start;
-  margin-bottom: 0.85rem;
-}
-
-.pps-level-id {
+.ppm-dl-icon {
+  width: 1.15rem;
+  height: 1.15rem;
   flex-shrink: 0;
-  font-size: 0.8rem;
-  font-weight: 500;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.4rem;
-  background: rgba(167, 139, 250, 0.12);
-  color: var(--accent-from);
-  border: 1px solid rgba(167, 139, 250, 0.25);
 }
 
-.pps-level-head h3 {
-  margin: 0 0 0.35rem;
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-}
-
-.pps-level-sub {
-  margin: 0;
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.pps-level ul {
-  margin: 0;
-  padding: 0 0 0 1.1rem;
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  line-height: 1.55;
-}
-
-.pps-level li + li {
-  margin-top: 0.4rem;
-}
-
-.pps-pills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.pps-pill {
-  padding: 0.45rem 0.75rem;
-  border-radius: 0.45rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  border: 1px solid var(--border);
-  background: rgba(16, 18, 26, 0.85);
-  color: #b8bdd4;
-}
-
-.pps-flywheel {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.pps-fly-item {
-  display: flex;
-  gap: 1rem;
-  align-items: flex-start;
-  padding: 1.1rem 1.2rem;
-  border-radius: 0.85rem;
-  border: 1px solid var(--border);
-  background: rgba(12, 14, 20, 0.55);
-}
-
-.pps-fly-index {
-  flex-shrink: 0;
-  font-size: 0.75rem;
-  color: var(--accent-to);
-  opacity: 0.95;
-  padding-top: 0.15rem;
-}
-
-.pps-fly-item strong {
-  display: block;
-  margin-bottom: 0.25rem;
-  font-size: 1rem;
-}
-
-.pps-fly-item p {
-  margin: 0;
-  font-size: 0.875rem;
-  color: var(--text-muted);
-}
-
-.pps-dim-grid {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+.ppm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   gap: 0.65rem;
+  padding: 1rem 2.5rem;
+  border-radius: 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-@media (min-width: 560px) {
-  .pps-dim-grid {
-    grid-template-columns: repeat(3, 1fr);
+.ppm-btn:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.ppm-btn-primary {
+  background: var(--ppm-ink);
+  color: #fff;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+}
+
+.ppm-btn-primary:hover {
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+}
+
+.ppm-btn-secondary {
+  background: transparent;
+  color: var(--ppm-text);
+  border-color: var(--ppm-border);
+}
+
+.ppm-btn-secondary:hover {
+  background: var(--ppm-surface-2);
+}
+
+.ppm-btn-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.ppm-section {
+  width: 100%;
+  margin: 0;
+  padding: clamp(2.5rem, 6vh, 4.5rem) 0;
+}
+
+/* 版面分区：白底块与浅灰底块交替，避免长页「糊成一片」 */
+#pain.ppm-section,
+#position.ppm-section,
+#faq.ppm-section {
+  background: var(--ppm-bg);
+  border-bottom: 1px solid var(--ppm-border);
+}
+
+#benefits.ppm-section {
+  background: var(--ppm-surface);
+  border-bottom: 1px solid var(--ppm-border);
+}
+
+.ppm-border-t {
+  border-top: 1px solid var(--ppm-border);
+}
+
+.ppm-center {
+  text-align: center;
+}
+
+.ppm-h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.ppm-muted-lg {
+  margin: 0 0 2rem;
+  font-size: 1.125rem;
+  color: var(--ppm-muted-lg);
+  line-height: 1.65;
+  max-width: 42rem;
+}
+
+.ppm-center .ppm-muted-lg {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ppm-pain-grid {
+  display: grid;
+  gap: 4rem;
+  align-items: center;
+}
+
+@media (min-width: 1024px) {
+  .ppm-pain-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 6rem;
   }
 }
 
-.pps-dim {
+.ppm-pain-list {
+  list-style: none;
   margin: 0;
-  text-align: center;
-  padding: 1rem 0.75rem;
-  border-radius: 0.65rem;
-  border: 1px solid var(--border);
-  font-size: 0.9rem;
-  font-weight: 600;
-  background: linear-gradient(180deg, rgba(26, 28, 42, 0.75), rgba(12, 14, 20, 0.45));
-}
-
-.pps-quote {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
-  text-align: center;
-}
-
-.pps-quote blockquote {
-  margin: 0 0 1.5rem;
   padding: 0;
-  border: none;
-}
-
-.pps-quote blockquote p {
-  margin: 0;
-  font-size: 1.0625rem;
-  line-height: 1.65;
-  color: #c8ccd8;
-  font-style: italic;
-}
-
-.pps-quote-btn {
-  margin: 0 auto;
-}
-
-.pps-faq {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
-.pps-faq-item {
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  background: rgba(12, 14, 20, 0.45);
-  padding: 0;
+.ppm-pain-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--ppm-border);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  color: #3f3f46;
+}
+
+.ppm-pain-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  flex-shrink: 0;
+  color: #a1a1aa;
+}
+
+.ppm-visual {
+  position: relative;
+  aspect-ratio: 1;
+  max-width: 28rem;
+  margin: 0 auto;
+}
+
+.ppm-visual-inner {
+  position: absolute;
+  inset: 0;
+  background: var(--ppm-surface);
+  border: 1px solid var(--ppm-border);
+  border-radius: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
 }
 
-.pps-faq-item summary {
-  padding: 1rem 1.15rem;
-  font-weight: 600;
-  font-size: 0.92rem;
-  cursor: pointer;
-  list-style: none;
+.ppm-visual-chaos {
+  position: absolute;
+  width: 6rem;
+  height: 2.75rem;
+  background: #fff;
+  border: 1px solid var(--ppm-border);
+  border-radius: 0.5rem;
+  opacity: 0.4;
+}
+
+.ppm-visual-chaos-a {
+  top: 22%;
+  left: 18%;
+  transform: rotate(-12deg);
+}
+
+.ppm-visual-chaos-b {
+  bottom: 22%;
+  right: 18%;
+  transform: rotate(6deg);
+  width: 7.5rem;
+}
+
+.ppm-visual-core {
+  position: relative;
+  z-index: 2;
+  width: 15rem;
+  height: 15rem;
+  background: #fff;
+  border: 2px solid var(--ppm-text);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.75rem;
+  text-align: center;
+}
+
+.ppm-visual-core-icon {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 0.75rem;
+  background: var(--ppm-ink);
+  color: #fff;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
 }
 
-.pps-faq-item summary::-webkit-details-marker {
-  display: none;
+.ppm-visual-box {
+  width: 1.75rem;
+  height: 1.75rem;
 }
 
-.pps-faq-item summary::after {
-  content: '+';
-  font-family: var(--font, 'DM Sans'), sans-serif;
-  font-weight: 400;
-  color: var(--text-muted);
-  font-size: 1.15rem;
-  line-height: 1;
-}
-
-.pps-faq-item[open] summary::after {
-  content: '−';
-}
-
-.pps-faq-item summary:hover {
-  background: rgba(20, 22, 34, 0.35);
-}
-
-.pps-faq-item p {
-  margin: 0;
-  padding: 0 1.15rem 1.1rem;
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  line-height: 1.6;
-  border-top: 1px solid var(--border);
-  padding-top: 0.85rem;
-}
-
-.pps-cta-band {
-  text-align: center;
-  padding: 4rem 1.5rem;
-  border-top: 1px solid var(--border);
-  background: radial-gradient(ellipse 70% 80% at 50% 100%, rgba(124, 58, 237, 0.18), transparent 60%),
-    linear-gradient(180deg, rgba(8, 9, 14, 0.95), rgba(4, 4, 6, 0.98));
-}
-
-.pps-cta-title {
-  margin: 0 auto 0.75rem;
-  max-width: 22em;
-  font-size: clamp(1.35rem, 3.2vw, 1.85rem);
+.ppm-visual-core-title {
   font-weight: 700;
-  letter-spacing: -0.03em;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.ppm-visual-bars {
+  margin-top: 1.25rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ppm-visual-bar {
+  display: block;
+  height: 0.375rem;
+  background: var(--ppm-surface-2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ppm-visual-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--ppm-text);
+  border-radius: 999px;
+}
+
+.ppm-visual-lines {
+  position: absolute;
+  inset: 0;
+  color: #000;
+  opacity: 0.08;
+  pointer-events: none;
+}
+
+.ppm-benefits-card {
+  background: #fff;
+  border: 1px solid #f4f4f5;
+  border-radius: 2.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  padding: 3rem 1.5rem;
+  margin: 0 0.25rem;
+}
+
+@media (min-width: 768px) {
+  .ppm-benefits-card {
+    padding: 3.5rem 3rem;
+  }
+}
+
+.ppm-benefits-grid {
+  display: grid;
+  gap: 3rem;
+}
+
+@media (min-width: 768px) {
+  .ppm-benefits-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4rem;
+  }
+}
+
+.ppm-benefit-icon-wrap {
+  display: flex;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  background: var(--ppm-surface);
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+}
+
+.ppm-benefit-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  color: #27272a;
+}
+
+.ppm-benefit-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
   line-height: 1.25;
+  white-space: pre-line;
 }
 
-.pps-cta-lead {
-  margin: 0 auto 1.75rem;
-  max-width: 32rem;
-  color: var(--text-muted);
-  font-size: 0.95rem;
-}
-
-.pps-footer {
-  margin-top: 0;
-  padding: 2.5rem 1.5rem;
-  border-top: 1px solid var(--border);
-  text-align: center;
-  color: var(--text-muted);
+.ppm-benefit-body {
+  margin: 0;
   font-size: 0.875rem;
+  color: var(--ppm-muted-lg);
+  line-height: 1.65;
 }
 
-.pps-footer p {
-  margin: 0 0 0.5rem;
+.ppm-orbit-wrap {
+  max-width: 56rem;
+  margin: 3rem auto 0;
+  position: relative;
 }
 
-.pps-footer a {
-  word-break: break-all;
-  color: var(--accent-to);
+.ppm-orbit-label {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--ppm-surface);
+  border: 1px solid var(--ppm-border);
+  padding: 0.35rem 1.25rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+  z-index: 2;
+}
+
+.ppm-orbit {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  border: 2px dashed var(--ppm-border);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+}
+
+.ppm-orbit-tag {
+  position: absolute;
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.35rem 0.65rem;
+  background: #fff;
+  border: 1px solid var(--ppm-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.ppm-orbit-tag-a {
+  top: 0.5rem;
+  left: 22%;
+}
+
+.ppm-orbit-tag-b {
+  bottom: 0.5rem;
+  right: 22%;
+}
+
+.ppm-orbit-tag-c {
+  right: -0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+@media (max-width: 640px) {
+  .ppm-orbit-tag-c {
+    right: 0.5rem;
+    top: auto;
+    bottom: 0.5rem;
+    transform: none;
+  }
+}
+
+.ppm-orbit-core {
+  width: 58%;
+  max-width: 22rem;
+  aspect-ratio: 16 / 10;
+  background: var(--ppm-ink);
+  color: #fff;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+  text-align: center;
+}
+
+.ppm-orbit-core-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  opacity: 0.55;
+  margin-bottom: 0.5rem;
+}
+
+.ppm-orbit-core-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+.ppm-orbit-core-meta {
+  margin: 0;
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+
+.ppm-band {
+  width: 100%;
+  background: var(--ppm-surface-2);
+  border-bottom: 1px solid var(--ppm-border);
+  padding: clamp(2.5rem, 6vh, 4.5rem) 0;
+}
+
+.ppm-band-grid {
+  display: grid;
+  gap: 3rem;
+}
+
+@media (min-width: 768px) {
+  .ppm-band-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 6rem;
+  }
+}
+
+.ppm-slash-list {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.ppm-slash-list > li {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.ppm-slash-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  color: #a1a1aa;
+  margin-top: 0.15rem;
+}
+
+.ppm-slash-h {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.ppm-slash-p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ppm-muted-lg);
+  line-height: 1.55;
+}
+
+.ppm-quote-card {
+  margin: 0;
+  padding: 2.5rem;
+  background: #fff;
+  border: 1px solid var(--ppm-border);
+  border-radius: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ppm-quote-label {
+  margin: 0 0 1rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+
+.ppm-quote-text {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: -0.02em;
+}
+
+.ppm-quote-foot {
+  margin-top: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.ppm-quote-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--ppm-text);
+}
+
+.ppm-quote-team {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.ppm-faq-label {
+  margin: 0 0 2.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+
+.ppm-faq-grid {
+  display: grid;
+  gap: 2.5rem 4rem;
+}
+
+@media (min-width: 768px) {
+  .ppm-faq-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.ppm-faq-q {
+  margin: 0 0 0.65rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.ppm-faq-a {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ppm-muted-lg);
+  line-height: 1.6;
+}
+
+.ppm-final-cta {
+  width: 100%;
+  background: var(--ppm-text);
+  color: #fff;
+  text-align: center;
+  padding: clamp(2.5rem, 6vh, 4.5rem) 0;
+}
+
+.ppm-final-title {
+  margin: 0 0 2rem;
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+}
+
+.ppm-final-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .ppm-final-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+.ppm-btn-on-dark {
+  padding: 1rem 2.5rem;
+  background: #fff;
+  color: var(--ppm-text);
+  border-radius: 0.75rem;
+  font-weight: 700;
+}
+
+.ppm-btn-on-dark:hover {
+  background: #e4e4e7;
+  text-decoration: none;
+}
+
+.ppm-link-on-dark {
+  color: #a1a1aa;
+  font-size: 0.95rem;
+  text-underline-offset: 0.5rem;
+}
+
+.ppm-link-on-dark:hover {
+  color: #fff;
+}
+
+.ppm-footer {
+  width: 100%;
+  border-top: 1px solid var(--ppm-border);
+  padding: 3rem 0;
+}
+
+.ppm-footer-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .ppm-footer-inner {
+    flex-direction: row;
+  }
+}
+
+.ppm-footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ppm-footer-mark {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 0.2rem;
+  background: var(--ppm-text);
+  color: #fff;
+  font-size: 0.55rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ppm-footer-name {
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ppm-footer-meta {
+  margin: 0;
+  font-size: 0.7rem;
+  color: #a1a1aa;
+  text-align: center;
+}
+
+.ppm-footer-gh {
+  color: var(--ppm-muted-lg);
+}
+
+.ppm-footer-gh:hover {
+  color: var(--ppm-text);
+  text-decoration: none;
+}
+
+.ppm-footer-gh-icon {
+  width: 1.35rem;
+  height: 1.35rem;
 }


### PR DESCRIPTION
Updates the Vite React marketing site under public-site: layout, global styles, HTML shell, and gitignore. Targets next for integration.

Made with [Cursor](https://cursor.com)