### PR TITLE
fix: CI agent-chat routes, legacy sessions by project, provider smoke paths

### DIFF
--- a/.github/workflows/provider-availability-smoke.yml
+++ b/.github/workflows/provider-availability-smoke.yml
@@ -6,12 +6,12 @@ name: Provider availability smoke
 on:
   pull_request:
     paths:
-      - 'src/lib/aggregate-models-live.ts'
+      - 'src/shared/lib/aggregate-models-live.ts'
       - 'src/server/routes/settings.ts'
-      - 'src/lib/settings-manager.ts'
+      - 'src/shared/lib/settings-manager.ts'
       - 'src/data/providers-registry.json'
-      - 'src/lib/provider-registry.ts'
-      - 'src/lib/model-health-check.ts'
+      - 'src/shared/lib/provider-registry.ts'
+      - 'src/shared/lib/model-health-check.ts'
       - 'scripts/provider-availability-smoke.ts'
       - 'provider-test.env.example'
 

--- a/scripts/ci-compute-pr-desktop-version.mjs
+++ b/scripts/ci-compute-pr-desktop-version.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * PR 桌面 CI：合并基线 `package.json` 的 X.Y.Z 做 **patch+1**，再拼 `-pr.<PR号>`；若存在环境变量
+ * **GITHUB_RUN_NUMBER**（Actions 默认注入），再拼 `.<run号>`，使「基线未 bump」时每次构建版本串仍不同。
+ *
+ * 基线 `version` 未变时，`0.1.6` 段会固定为 patch+1；要升正式号请在 `next` 上 `npm run release:desktop:bump` 或改 `package.json`。
+ *
+ * 用法：node scripts/ci-compute-pr-desktop-version.mjs <pr_number>
+ *  stdout：例如 0.1.6-pr.42 或 0.1.6-pr.42.184523
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pr = process.argv[2];
+if (!pr || !/^\d+$/.test(pr)) {
+  console.error('Usage: node scripts/ci-compute-pr-desktop-version.mjs <pr_number>');
+  process.exit(1);
+}
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const raw = String(pkg.version ?? '0.0.0');
+const m = raw.match(/^(\d+)\.(\d+)\.(\d+)/);
+if (!m) {
+  console.error(`ci-compute-pr-desktop-version: cannot parse X.Y.Z prefix from "${raw}"`);
+  process.exit(1);
+}
+const major = m[1];
+const minor = m[2];
+const patch = Number(m[3]) + 1;
+const run = process.env.GITHUB_RUN_NUMBER?.trim() ?? '';
+const runSuffix = /^\d+$/.test(run) ? `.${run}` : '';
+const v = `${major}.${minor}.${patch}-pr.${pr}${runSuffix}`;
+process.stdout.write(v);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -163,11 +163,11 @@ app.route(api.recycleBin, lazyApiRoute(api.recycleBin, () => import('./routes/re
 app.route(api.upload, lazyApiRoute(api.upload, () => import('./routes/upload')));
 app.route(api.projects, lazyApiRoute(api.projects, () => import('./routes/projects')));
 app.route(api.aiDiscuss, lazyApiRoute(api.aiDiscuss, () => import('./routes/ai-discuss')));
-app.route(api.agentChat, lazyApiRoute(api.agentChat, () => import('./routes/agent-chat')));
+app.route(api.agentChat, lazyApiRoute(api.agentChat, () => import('./routes/agents/agent-chat')));
 app.route(api.schedules, lazyApiRoute(api.schedules, () => import('./routes/schedules')));
 app.route(api.eventTriggers, lazyApiRoute(api.eventTriggers, () => import('./routes/event-triggers')));
 app.route(api.community, lazyApiRoute(api.community, () => import('./routes/community')));
-app.route(api.agentInbox, lazyApiRoute(api.agentInbox, () => import('./routes/agent-inbox')));
+app.route(api.agentInbox, lazyApiRoute(api.agentInbox, () => import('./routes/agents/agent-inbox')));
 app.route(api.distiller, lazyApiRoute(api.distiller, () => import('./routes/distiller')));
 app.route(api.googleAuth, lazyApiRoute(api.googleAuth, () => import('./routes/google-auth')));
 /** 须挂在所有其它 `/api/...` 子树之后，否则会吞掉 `/api/auth/google` 等路径并 404 */

--- a/src/server/routes/agents/agent-chat.ts
+++ b/src/server/routes/agents/agent-chat.ts
@@ -635,7 +635,8 @@ app.get('/sessions', async (c) => {
     sessions = await listSessions(agentId);
   } else if (projectKey) {
     const all = await listAllSessions();
-    sessions = all.filter(s => s.projectKey === projectKey);
+    // 与 Agents 侧栏 project 过滤一致：无 projectKey 的会话视为全局/旧版落盘，仍应在当前项目下可见
+    sessions = all.filter(s => !s.projectKey || s.projectKey === projectKey);
   } else {
     sessions = await listAllSessions();
   }

--- a/src/shared/lib/chat-managers/agent-chat-session-store.ts
+++ b/src/shared/lib/chat-managers/agent-chat-session-store.ts
@@ -509,7 +509,12 @@ export async function listSessions(agentId: string): Promise<Omit<AgentChatSessi
 export async function listSessionsByProject(agentId: string, projectKey: string): Promise<Omit<AgentChatSession, 'messages'>[]> {
   const data = await getIndexData();
   return data.sessions
-    .filter(s => s.agentId === agentId && s.projectKey === projectKey && !isEphemeralTestSession(s.id))
+    .filter(
+      s =>
+        s.agentId === agentId
+        && (!s.projectKey || s.projectKey === projectKey)
+        && !isEphemeralTestSession(s.id),
+    )
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 }
 


### PR DESCRIPTION
Follow-up after workspace layout merge (PR #95).

- Restore scripts/ci-compute-pr-desktop-version.mjs for PR desktop CI.
- Fix lazy imports in src/server/index.ts to routes/agents/agent-chat and agent-inbox (Bun bundle).
- Align session listing when projectKey is set: include sessions with no projectKey (legacy/global).
- Update provider-availability-smoke workflow paths to src/shared/lib/*.

Made with [Cursor](https://cursor.com)